### PR TITLE
Seph/initial import

### DIFF
--- a/output/packs/hardware-monitoring.conf
+++ b/output/packs/hardware-monitoring.conf
@@ -1,0 +1,124 @@
+{
+  "queries": {
+    "acpi_tables": {
+      "query": "select * from acpi_tables;",
+      "interval": 86400,
+      "platform": "posix",
+      "version": "1.3.0",
+      "description": "General reporting and heuristics monitoring."
+    },
+    "cpuid": {
+      "query": "select feature, value, output_register, output_bit, input_eax from cpuid;",
+      "interval": 86400,
+      "version": "1.0.4",
+      "description": "General reporting and heuristics monitoring."
+    },
+    "smbios_tables": {
+      "query": "select * from smbios_tables;",
+      "interval": 86400,
+      "platform": "posix",
+      "version": "1.3.0",
+      "description": "General reporting and heuristics monitoring."
+    },
+    "nvram": {
+      "query": "select * from nvram where name not in ('backlight-level', 'SystemAudioVolumeDB', 'SystemAudioVolume');",
+      "interval": 7200,
+      "platform": "darwin",
+      "version": "1.0.2",
+      "description": "Report on crashes, alternate boots, and boot arguments."
+    },
+    "kernel_info": {
+      "query": "select * from kernel_info join hash using (path);",
+      "interval": 7200,
+      "version": "1.4.0",
+      "description": "Report the booted kernel, potential arguments, and the device."
+    },
+    "pci_devices": {
+      "query": "select * from pci_devices;",
+      "interval": 7200,
+      "platform": "posix",
+      "version": "1.0.4",
+      "description": "Report an inventory of PCI devices. Attaches and detaches will show up in hardware_events."
+    },
+    "fan_speeds": {
+      "query": "select * from fan_speed_sensors;",
+      "interval": 7200,
+      "platform": "darwin",
+      "version": "1.7.1",
+      "description": "Report current fan speeds in the target OSX system."
+    },
+    "temperatures": {
+      "query": "select * from temperature_sensors;",
+      "interval": 7200,
+      "platform": "darwin",
+      "version": "1.7.1",
+      "description": "Report current machine temperatures in the target OSX system."
+    },
+    "usb_devices": {
+      "query": "select * from usb_devices;",
+      "interval": 7200,
+      "platform": "posix",
+      "version": "1.2.0",
+      "description": "Report an inventory of USB devices. Attaches and detaches will show up in hardware_events."
+    },
+    "hardware_events": {
+      "query" : "select * from hardware_events where path <> '' or model <> '';",
+      "interval" : 7200,
+      "platform": "posix",
+      "removed": false,
+      "version" : "1.4.5",
+      "description" : "Retrieves all the hardware related events in the target OSX system.",
+      "value" : "Determine if a third party device was attached to the system."
+    },
+    "darwin_kernel_system_controls": {
+      "query": "select * from system_controls where subsystem = 'kern' and (name like '%boot%' or name like '%secure%' or name like '%single%');",
+      "interval": 7200,
+      "platform": "darwin",
+      "version": "1.4.3",
+      "description": "Double check the information reported in kernel_info and report the kernel signature."
+    },
+    "iokit_devicetree": {
+      "query": "select * from iokit_devicetree;",
+      "interval": 86400,
+      "platform": "darwin",
+      "version": "1.3.0",
+      "description": "General inventory of IOKit's devices on OS X."
+    },
+    "efi_file_hashes": {
+      "query": "select file.path, uid, gid, mode, 0 as atime, mtime, ctime, md5, sha1, sha256 from (select * from file where path like '/System/Library/CoreServices/%.efi' union select * from file where path like '/System/Library/LaunchDaemons/com.apple%efi%') file join hash using (path);",
+      "interval": 7200,
+      "removed": false,
+      "version": "1.6.1",
+      "platform": "darwin",
+      "description": "Hash files related to EFI platform updates and EFI bootloaders on primary boot partition. This does not hash bootloaders on the EFI/boot partition."
+    },
+    "kernel_extensions": {
+      "query" : "select * from kernel_extensions;",
+      "interval" : "7200",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the information about the current kernel extensions for the target OSX system."
+    },
+    "kernel_modules": {
+      "query" : "select * from kernel_modules;",
+      "interval" : "7200",
+      "platform" : "linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the information for the current kernel modules in the target Linux system."
+    },
+    "windows_drivers": {
+      "query" : "select * from drivers;",
+      "interval" : "7200",
+      "platform" : "windows",
+      "version" : "2.2.0",
+      "description" : "Retrieves all the information for the current windows drivers in the target Windows system."
+    },
+    "device_nodes": {
+      "query": "select file.path, uid, gid, mode, 0 as atime, mtime, ctime, block_size, type from file where directory = '/dev/';",
+      "interval": "7200",
+      "platform": "posix",
+      "version": "1.6.0",
+      "description": "Inventory all 'device' nodes in /dev/."
+    }
+  }
+}

--- a/output/packs/hardware-monitoring.conf
+++ b/output/packs/hardware-monitoring.conf
@@ -1,124 +1,124 @@
 {
   "queries": {
     "acpi_tables": {
-      "query": "select * from acpi_tables;",
+      "description": "General reporting and heuristics monitoring.",
       "interval": 86400,
       "platform": "posix",
-      "version": "1.3.0",
-      "description": "General reporting and heuristics monitoring."
+      "query": "select * from acpi_tables;",
+      "version": "1.3.0"
     },
     "cpuid": {
+      "description": "General reporting and heuristics monitoring.",
+      "interval": 86400,
       "query": "select feature, value, output_register, output_bit, input_eax from cpuid;",
-      "interval": 86400,
-      "version": "1.0.4",
-      "description": "General reporting and heuristics monitoring."
-    },
-    "smbios_tables": {
-      "query": "select * from smbios_tables;",
-      "interval": 86400,
-      "platform": "posix",
-      "version": "1.3.0",
-      "description": "General reporting and heuristics monitoring."
-    },
-    "nvram": {
-      "query": "select * from nvram where name not in ('backlight-level', 'SystemAudioVolumeDB', 'SystemAudioVolume');",
-      "interval": 7200,
-      "platform": "darwin",
-      "version": "1.0.2",
-      "description": "Report on crashes, alternate boots, and boot arguments."
-    },
-    "kernel_info": {
-      "query": "select * from kernel_info join hash using (path);",
-      "interval": 7200,
-      "version": "1.4.0",
-      "description": "Report the booted kernel, potential arguments, and the device."
-    },
-    "pci_devices": {
-      "query": "select * from pci_devices;",
-      "interval": 7200,
-      "platform": "posix",
-      "version": "1.0.4",
-      "description": "Report an inventory of PCI devices. Attaches and detaches will show up in hardware_events."
-    },
-    "fan_speeds": {
-      "query": "select * from fan_speed_sensors;",
-      "interval": 7200,
-      "platform": "darwin",
-      "version": "1.7.1",
-      "description": "Report current fan speeds in the target OSX system."
-    },
-    "temperatures": {
-      "query": "select * from temperature_sensors;",
-      "interval": 7200,
-      "platform": "darwin",
-      "version": "1.7.1",
-      "description": "Report current machine temperatures in the target OSX system."
-    },
-    "usb_devices": {
-      "query": "select * from usb_devices;",
-      "interval": 7200,
-      "platform": "posix",
-      "version": "1.2.0",
-      "description": "Report an inventory of USB devices. Attaches and detaches will show up in hardware_events."
-    },
-    "hardware_events": {
-      "query" : "select * from hardware_events where path <> '' or model <> '';",
-      "interval" : 7200,
-      "platform": "posix",
-      "removed": false,
-      "version" : "1.4.5",
-      "description" : "Retrieves all the hardware related events in the target OSX system.",
-      "value" : "Determine if a third party device was attached to the system."
+      "version": "1.0.4"
     },
     "darwin_kernel_system_controls": {
+      "description": "Double check the information reported in kernel_info and report the kernel signature.",
+      "interval": 7200,
+      "platform": "darwin",
       "query": "select * from system_controls where subsystem = 'kern' and (name like '%boot%' or name like '%secure%' or name like '%single%');",
-      "interval": 7200,
-      "platform": "darwin",
-      "version": "1.4.3",
-      "description": "Double check the information reported in kernel_info and report the kernel signature."
-    },
-    "iokit_devicetree": {
-      "query": "select * from iokit_devicetree;",
-      "interval": 86400,
-      "platform": "darwin",
-      "version": "1.3.0",
-      "description": "General inventory of IOKit's devices on OS X."
-    },
-    "efi_file_hashes": {
-      "query": "select file.path, uid, gid, mode, 0 as atime, mtime, ctime, md5, sha1, sha256 from (select * from file where path like '/System/Library/CoreServices/%.efi' union select * from file where path like '/System/Library/LaunchDaemons/com.apple%efi%') file join hash using (path);",
-      "interval": 7200,
-      "removed": false,
-      "version": "1.6.1",
-      "platform": "darwin",
-      "description": "Hash files related to EFI platform updates and EFI bootloaders on primary boot partition. This does not hash bootloaders on the EFI/boot partition."
-    },
-    "kernel_extensions": {
-      "query" : "select * from kernel_extensions;",
-      "interval" : "7200",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the information about the current kernel extensions for the target OSX system."
-    },
-    "kernel_modules": {
-      "query" : "select * from kernel_modules;",
-      "interval" : "7200",
-      "platform" : "linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the information for the current kernel modules in the target Linux system."
-    },
-    "windows_drivers": {
-      "query" : "select * from drivers;",
-      "interval" : "7200",
-      "platform" : "windows",
-      "version" : "2.2.0",
-      "description" : "Retrieves all the information for the current windows drivers in the target Windows system."
+      "version": "1.4.3"
     },
     "device_nodes": {
-      "query": "select file.path, uid, gid, mode, 0 as atime, mtime, ctime, block_size, type from file where directory = '/dev/';",
+      "description": "Inventory all 'device' nodes in /dev/.",
       "interval": "7200",
       "platform": "posix",
-      "version": "1.6.0",
-      "description": "Inventory all 'device' nodes in /dev/."
+      "query": "select file.path, uid, gid, mode, 0 as atime, mtime, ctime, block_size, type from file where directory = '/dev/';",
+      "version": "1.6.0"
+    },
+    "efi_file_hashes": {
+      "description": "Hash files related to EFI platform updates and EFI bootloaders on primary boot partition. This does not hash bootloaders on the EFI/boot partition.",
+      "interval": 7200,
+      "platform": "darwin",
+      "query": "select file.path, uid, gid, mode, 0 as atime, mtime, ctime, md5, sha1, sha256 from (select * from file where path like '/System/Library/CoreServices/%.efi' union select * from file where path like '/System/Library/LaunchDaemons/com.apple%efi%') file join hash using (path);",
+      "removed": false,
+      "version": "1.6.1"
+    },
+    "fan_speeds": {
+      "description": "Report current fan speeds in the target OSX system.",
+      "interval": 7200,
+      "platform": "darwin",
+      "query": "select * from fan_speed_sensors;",
+      "version": "1.7.1"
+    },
+    "hardware_events": {
+      "description": "Retrieves all the hardware related events in the target OSX system.",
+      "interval": 7200,
+      "platform": "posix",
+      "query": "select * from hardware_events where path <> '' or model <> '';",
+      "removed": false,
+      "value": "Determine if a third party device was attached to the system.",
+      "version": "1.4.5"
+    },
+    "iokit_devicetree": {
+      "description": "General inventory of IOKit's devices on OS X.",
+      "interval": 86400,
+      "platform": "darwin",
+      "query": "select * from iokit_devicetree;",
+      "version": "1.3.0"
+    },
+    "kernel_extensions": {
+      "description": "Retrieves all the information about the current kernel extensions for the target OSX system.",
+      "interval": "7200",
+      "platform": "darwin",
+      "query": "select * from kernel_extensions;",
+      "version": "1.4.5"
+    },
+    "kernel_info": {
+      "description": "Report the booted kernel, potential arguments, and the device.",
+      "interval": 7200,
+      "query": "select * from kernel_info join hash using (path);",
+      "version": "1.4.0"
+    },
+    "kernel_modules": {
+      "description": "Retrieves all the information for the current kernel modules in the target Linux system.",
+      "interval": "7200",
+      "platform": "linux",
+      "query": "select * from kernel_modules;",
+      "version": "1.4.5"
+    },
+    "nvram": {
+      "description": "Report on crashes, alternate boots, and boot arguments.",
+      "interval": 7200,
+      "platform": "darwin",
+      "query": "select * from nvram where name not in ('backlight-level', 'SystemAudioVolumeDB', 'SystemAudioVolume');",
+      "version": "1.0.2"
+    },
+    "pci_devices": {
+      "description": "Report an inventory of PCI devices. Attaches and detaches will show up in hardware_events.",
+      "interval": 7200,
+      "platform": "posix",
+      "query": "select * from pci_devices;",
+      "version": "1.0.4"
+    },
+    "smbios_tables": {
+      "description": "General reporting and heuristics monitoring.",
+      "interval": 86400,
+      "platform": "posix",
+      "query": "select * from smbios_tables;",
+      "version": "1.3.0"
+    },
+    "temperatures": {
+      "description": "Report current machine temperatures in the target OSX system.",
+      "interval": 7200,
+      "platform": "darwin",
+      "query": "select * from temperature_sensors;",
+      "version": "1.7.1"
+    },
+    "usb_devices": {
+      "description": "Report an inventory of USB devices. Attaches and detaches will show up in hardware_events.",
+      "interval": 7200,
+      "platform": "posix",
+      "query": "select * from usb_devices;",
+      "version": "1.2.0"
+    },
+    "windows_drivers": {
+      "description": "Retrieves all the information for the current windows drivers in the target Windows system.",
+      "interval": "7200",
+      "platform": "windows",
+      "query": "select * from drivers;",
+      "version": "2.2.0"
     }
   }
 }

--- a/output/packs/incident-response.conf
+++ b/output/packs/incident-response.conf
@@ -1,0 +1,283 @@
+{
+  "queries": {
+    "launchd": {
+      "query" : "select * from launchd;",
+      "interval" : "3600",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the daemons that will run in the start of the target OSX system.",
+      "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
+    },
+    "startup_items": {
+      "query" : "select * from startup_items;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieve all the items that will load when the target OSX system starts.",
+      "value" : "Identify malware that uses this persistence mechanism to launch at a given interval"
+    },
+    "crontab": {
+      "query" : "select * from crontab;",
+      "interval" : "3600",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the jobs scheduled in crontab in the target system.",
+      "value" : "Identify malware that uses this persistence mechanism to launch at a given interval"
+    },
+    "loginwindow1": {
+      "query" : "select key, subkey, value from plist where path = '/Library/Preferences/com.apple.loginwindow.plist';",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the values for the loginwindow process in the target OSX system.",
+      "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
+    },
+    "loginwindow2": {
+      "query" : "select key, subkey, value from plist where path = '/Library/Preferences/loginwindow.plist';",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the values for the loginwindow process in the target OSX system.",
+      "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
+    },
+    "loginwindow3": {
+      "query" : "select username, key, subkey, value from plist p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/com.apple.loginwindow.plist';",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the values for the loginwindow process in the target OSX system.",
+      "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
+    },
+    "loginwindow4": {
+      "query" : "select username, key, subkey, value from plist p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/loginwindow.plist';",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the values for the loginwindow process in the target OSX system.",
+      "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
+    },
+    "alf": {
+      "query" : "select * from alf;",
+      "interval" : "3600",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the configuration values for the Application Layer Firewall for OSX.",
+      "value" : "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans"
+    },
+    "alf_exceptions": {
+      "query" : "select * from alf_exceptions;",
+      "interval" : "3600",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the exceptions for the Application Layer Firewall in OSX.",
+      "value" : "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans"
+    },
+    "alf_services": {
+      "query" : "select * from alf_services;",
+      "interval" : "3600",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the services for the Application Layer Firewall in OSX.",
+      "value" : "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans"
+    },
+    "alf_explicit_auths": {
+      "query" : "select * from alf_explicit_auths;",
+      "interval" : "3600",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the list of processes with explicit authorization for the Application Layer Firewall.",
+      "value" : "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans"
+    },
+    "etc_hosts": {
+      "query" : "select * from etc_hosts;",
+      "interval" : "86400",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the entries in the target system /etc/hosts file.",
+      "value" : "Identify network communications that are being redirected. Example: identify if security logging has been disabled"
+    },
+    "kextstat": {
+      "query" : "select * from kernel_extensions;",
+      "interval" : "3600",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the information about the current kernel extensions for the target OSX system.",
+      "value" : "Identify malware that has a kernel extension component."
+    },
+    "kernel_modules": {
+      "query" : "select * from kernel_modules;",
+      "interval" : "3600",
+      "platform" : "linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the information for the current kernel modules in the target Linux system.",
+      "value" : "Identify malware that has a kernel module component."
+    },
+    "last": {
+      "query" : "select * from last;",
+      "interval" : "3600",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves the list of the latest logins with PID, username and timestamp.",
+      "value" : "Useful for intrusion detection and incident response. Verify assumptions of what accounts should be accessing what systems and identify machines accessed during a compromise."
+    },
+    "installed_applications": {
+      "query" : "select * from apps;",
+      "interval" : "3600",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the currently installed applications in the target OSX system.",
+      "value" : "Identify malware, adware, or vulnerable packages that are installed as an application."
+    },
+    "open_sockets": {
+      "query" : "select distinct pid, family, protocol, local_address, local_port, remote_address, remote_port, path from process_open_sockets where path <> '' or remote_address <> '';",
+      "interval" : "86400",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the open sockets per process in the target system.",
+      "value" : "Identify malware via connections to known bad IP addresses as well as odd local or remote port bindings"
+    },
+    "open_files": {
+      "query" : "select distinct pid, path from process_open_files where path not like '/private/var/folders%' and path not like '/System/Library/%' and path not in ('/dev/null', '/dev/urandom', '/dev/random');",
+      "interval" : "86400",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the open files per process in the target system.",
+      "value" : "Identify processes accessing sensitive files they shouldn't"
+    },
+    "logged_in_users": {
+      "query" : "select liu.*, p.name, p.cmdline, p.cwd, p.root from logged_in_users liu, processes p where liu.pid = p.pid;",
+      "interval" : "3600",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves the list of all the currently logged in users in the target system.",
+      "value" : "Useful for intrusion detection and incident response. Verify assumptions of what accounts should be accessing what systems and identify machines accessed during a compromise."
+    },
+    "ip_forwarding": {
+      "query" : "select * from system_controls where oid = '4.30.41.1' union select * from system_controls where oid = '4.2.0.1';",
+      "interval" : "3600",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current status of IP/IPv6 forwarding.",
+      "value" : "Identify if a machine is being used as relay."
+    },
+    "process_env": {
+      "query" : "select * from process_envs;",
+      "interval" : "86400",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the environment variables per process in the target system.",
+      "value" : "Insight into the process data: Where was it started from, was it preloaded..."
+    },
+    "mounts": {
+      "query" : "select * from mounts;",
+      "interval" : "3600",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current list of mounted drives in the target system.",
+      "value" : "Scope for lateral movement. Potential exfiltration locations. Potential dormant backdoors."
+    },
+    "nfs_shares": {
+      "query" : "select * from nfs_shares;",
+      "interval" : "3600",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current list of Network File System mounted shares.",
+      "value" : "Scope for lateral movement. Potential exfiltration locations. Potential dormant backdoors."
+    },
+    "shell_history": {
+      "query" : "select * from users join shell_history using (uid);",
+      "interval" : "86400",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves the command history, per user, by parsing the shell history files.",
+      "value" : "Identify actions taken. Useful for compromised hosts."
+    },
+    "recent_items": {
+      "query" : "select username, key, value from plist p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/com.apple.recentitems.plist';",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the list of recent items opened in OSX by parsing the plist per user.",
+      "value" : "Identify recently accessed items. Useful for compromised hosts."
+    },
+    "ramdisk": {
+      "query" : "select * from block_devices where type = 'Virtual Interface';",
+      "interval" : "3600",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the ramdisk currently mounted in the target system.",
+      "value" : "Identify if an attacker is using temporary, memory storage to avoid touching disk for anti-forensics purposes"
+    },
+    "listening_ports": {
+      "query" : "select * from listening_ports;",
+      "interval" : "3600",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the listening ports in the target system.",
+      "value" : "Detect if a listening port iis not mapped to a known process. Find backdoors."
+    },
+    "suid_bin": {
+      "query" : "select * from suid_bin;",
+      "interval" : "3600",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the files in the target system that are setuid enabled.",
+      "value" : "Detect backdoor binaries (attacker may drop a copy of /bin/sh). Find potential elevation points / vulnerabilities in the standard build."
+    },
+    "process_memory": {
+      "query" : "select * from process_memory_map;",
+      "interval" : "86400",
+      "platform" : "linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves the memory map per process in the target Linux system.",
+      "value" : "Ability to compare with known good. Identify mapped regions corresponding with or containing injected code."
+    },
+    "arp_cache": {
+      "query" : "select * from arp_cache;",
+      "interval" : "3600",
+      "version" : "1.4.5",
+      "description" : "Retrieves the ARP cache values in the target system.",
+      "value" : "Determine if MITM in progress."
+    },
+    "wireless_networks": {
+      "query" : "select ssid, network_name, security_type, last_connected, captive_portal, possibly_hidden, roaming, roaming_profile from wifi_networks;",
+      "interval" : "3600",
+      "platform" : "darwin",
+      "version" : "1.6.0",
+      "description" : "Retrieves all the remembered wireless network that the target machine has connected to.",
+      "value" : "Identifies connections to rogue access points."
+    },
+    "disk_encryption": {
+      "query" : "select * from disk_encryption;",
+      "interval" : "86400",
+      "platform": "posix",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current disk encryption status for the target system.",
+      "value" : "Identifies a system potentially vulnerable to disk cloning."
+    },
+    "iptables": {
+      "query" : "select * from iptables;",
+      "interval" : "3600",
+      "platform" : "linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current filters and chains per filter in the target system.",
+      "value" : "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans"
+    },
+    "app_schemes": {
+      "query" : "select * from app_schemes;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.7",
+      "description" : "Retrieves the list of application scheme/protocol-based IPC handlers.",
+      "value" : "Post-priori hijack detection, detect potential sensitive information leakage."
+    },
+    "sandboxes": {
+      "query" : "select * from sandboxes;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.7",
+      "description" : "Lists the application bundle that owns a sandbox label.",
+      "value" : "Post-priori hijack detection, detect potential sensitive information leakage."
+    }
+  }
+}

--- a/output/packs/incident-response.conf
+++ b/output/packs/incident-response.conf
@@ -1,283 +1,283 @@
 {
   "queries": {
-    "launchd": {
-      "query" : "select * from launchd;",
-      "interval" : "3600",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the daemons that will run in the start of the target OSX system.",
-      "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
-    },
-    "startup_items": {
-      "query" : "select * from startup_items;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieve all the items that will load when the target OSX system starts.",
-      "value" : "Identify malware that uses this persistence mechanism to launch at a given interval"
-    },
-    "crontab": {
-      "query" : "select * from crontab;",
-      "interval" : "3600",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the jobs scheduled in crontab in the target system.",
-      "value" : "Identify malware that uses this persistence mechanism to launch at a given interval"
-    },
-    "loginwindow1": {
-      "query" : "select key, subkey, value from plist where path = '/Library/Preferences/com.apple.loginwindow.plist';",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the values for the loginwindow process in the target OSX system.",
-      "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
-    },
-    "loginwindow2": {
-      "query" : "select key, subkey, value from plist where path = '/Library/Preferences/loginwindow.plist';",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the values for the loginwindow process in the target OSX system.",
-      "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
-    },
-    "loginwindow3": {
-      "query" : "select username, key, subkey, value from plist p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/com.apple.loginwindow.plist';",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the values for the loginwindow process in the target OSX system.",
-      "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
-    },
-    "loginwindow4": {
-      "query" : "select username, key, subkey, value from plist p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/loginwindow.plist';",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the values for the loginwindow process in the target OSX system.",
-      "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
-    },
     "alf": {
-      "query" : "select * from alf;",
-      "interval" : "3600",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the configuration values for the Application Layer Firewall for OSX.",
-      "value" : "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans"
+      "description": "Retrieves the configuration values for the Application Layer Firewall for OSX.",
+      "interval": "3600",
+      "platform": "darwin",
+      "query": "select * from alf;",
+      "value": "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans",
+      "version": "1.4.5"
     },
     "alf_exceptions": {
-      "query" : "select * from alf_exceptions;",
-      "interval" : "3600",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the exceptions for the Application Layer Firewall in OSX.",
-      "value" : "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans"
-    },
-    "alf_services": {
-      "query" : "select * from alf_services;",
-      "interval" : "3600",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the services for the Application Layer Firewall in OSX.",
-      "value" : "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans"
+      "description": "Retrieves the exceptions for the Application Layer Firewall in OSX.",
+      "interval": "3600",
+      "platform": "darwin",
+      "query": "select * from alf_exceptions;",
+      "value": "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans",
+      "version": "1.4.5"
     },
     "alf_explicit_auths": {
-      "query" : "select * from alf_explicit_auths;",
-      "interval" : "3600",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the list of processes with explicit authorization for the Application Layer Firewall.",
-      "value" : "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans"
+      "description": "Retrieves the list of processes with explicit authorization for the Application Layer Firewall.",
+      "interval": "3600",
+      "platform": "darwin",
+      "query": "select * from alf_explicit_auths;",
+      "value": "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans",
+      "version": "1.4.5"
     },
-    "etc_hosts": {
-      "query" : "select * from etc_hosts;",
-      "interval" : "86400",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the entries in the target system /etc/hosts file.",
-      "value" : "Identify network communications that are being redirected. Example: identify if security logging has been disabled"
-    },
-    "kextstat": {
-      "query" : "select * from kernel_extensions;",
-      "interval" : "3600",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the information about the current kernel extensions for the target OSX system.",
-      "value" : "Identify malware that has a kernel extension component."
-    },
-    "kernel_modules": {
-      "query" : "select * from kernel_modules;",
-      "interval" : "3600",
-      "platform" : "linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the information for the current kernel modules in the target Linux system.",
-      "value" : "Identify malware that has a kernel module component."
-    },
-    "last": {
-      "query" : "select * from last;",
-      "interval" : "3600",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves the list of the latest logins with PID, username and timestamp.",
-      "value" : "Useful for intrusion detection and incident response. Verify assumptions of what accounts should be accessing what systems and identify machines accessed during a compromise."
-    },
-    "installed_applications": {
-      "query" : "select * from apps;",
-      "interval" : "3600",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the currently installed applications in the target OSX system.",
-      "value" : "Identify malware, adware, or vulnerable packages that are installed as an application."
-    },
-    "open_sockets": {
-      "query" : "select distinct pid, family, protocol, local_address, local_port, remote_address, remote_port, path from process_open_sockets where path <> '' or remote_address <> '';",
-      "interval" : "86400",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the open sockets per process in the target system.",
-      "value" : "Identify malware via connections to known bad IP addresses as well as odd local or remote port bindings"
-    },
-    "open_files": {
-      "query" : "select distinct pid, path from process_open_files where path not like '/private/var/folders%' and path not like '/System/Library/%' and path not in ('/dev/null', '/dev/urandom', '/dev/random');",
-      "interval" : "86400",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the open files per process in the target system.",
-      "value" : "Identify processes accessing sensitive files they shouldn't"
-    },
-    "logged_in_users": {
-      "query" : "select liu.*, p.name, p.cmdline, p.cwd, p.root from logged_in_users liu, processes p where liu.pid = p.pid;",
-      "interval" : "3600",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves the list of all the currently logged in users in the target system.",
-      "value" : "Useful for intrusion detection and incident response. Verify assumptions of what accounts should be accessing what systems and identify machines accessed during a compromise."
-    },
-    "ip_forwarding": {
-      "query" : "select * from system_controls where oid = '4.30.41.1' union select * from system_controls where oid = '4.2.0.1';",
-      "interval" : "3600",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current status of IP/IPv6 forwarding.",
-      "value" : "Identify if a machine is being used as relay."
-    },
-    "process_env": {
-      "query" : "select * from process_envs;",
-      "interval" : "86400",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the environment variables per process in the target system.",
-      "value" : "Insight into the process data: Where was it started from, was it preloaded..."
-    },
-    "mounts": {
-      "query" : "select * from mounts;",
-      "interval" : "3600",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current list of mounted drives in the target system.",
-      "value" : "Scope for lateral movement. Potential exfiltration locations. Potential dormant backdoors."
-    },
-    "nfs_shares": {
-      "query" : "select * from nfs_shares;",
-      "interval" : "3600",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current list of Network File System mounted shares.",
-      "value" : "Scope for lateral movement. Potential exfiltration locations. Potential dormant backdoors."
-    },
-    "shell_history": {
-      "query" : "select * from users join shell_history using (uid);",
-      "interval" : "86400",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves the command history, per user, by parsing the shell history files.",
-      "value" : "Identify actions taken. Useful for compromised hosts."
-    },
-    "recent_items": {
-      "query" : "select username, key, value from plist p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/com.apple.recentitems.plist';",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the list of recent items opened in OSX by parsing the plist per user.",
-      "value" : "Identify recently accessed items. Useful for compromised hosts."
-    },
-    "ramdisk": {
-      "query" : "select * from block_devices where type = 'Virtual Interface';",
-      "interval" : "3600",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the ramdisk currently mounted in the target system.",
-      "value" : "Identify if an attacker is using temporary, memory storage to avoid touching disk for anti-forensics purposes"
-    },
-    "listening_ports": {
-      "query" : "select * from listening_ports;",
-      "interval" : "3600",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the listening ports in the target system.",
-      "value" : "Detect if a listening port iis not mapped to a known process. Find backdoors."
-    },
-    "suid_bin": {
-      "query" : "select * from suid_bin;",
-      "interval" : "3600",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the files in the target system that are setuid enabled.",
-      "value" : "Detect backdoor binaries (attacker may drop a copy of /bin/sh). Find potential elevation points / vulnerabilities in the standard build."
-    },
-    "process_memory": {
-      "query" : "select * from process_memory_map;",
-      "interval" : "86400",
-      "platform" : "linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves the memory map per process in the target Linux system.",
-      "value" : "Ability to compare with known good. Identify mapped regions corresponding with or containing injected code."
-    },
-    "arp_cache": {
-      "query" : "select * from arp_cache;",
-      "interval" : "3600",
-      "version" : "1.4.5",
-      "description" : "Retrieves the ARP cache values in the target system.",
-      "value" : "Determine if MITM in progress."
-    },
-    "wireless_networks": {
-      "query" : "select ssid, network_name, security_type, last_connected, captive_portal, possibly_hidden, roaming, roaming_profile from wifi_networks;",
-      "interval" : "3600",
-      "platform" : "darwin",
-      "version" : "1.6.0",
-      "description" : "Retrieves all the remembered wireless network that the target machine has connected to.",
-      "value" : "Identifies connections to rogue access points."
-    },
-    "disk_encryption": {
-      "query" : "select * from disk_encryption;",
-      "interval" : "86400",
-      "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current disk encryption status for the target system.",
-      "value" : "Identifies a system potentially vulnerable to disk cloning."
-    },
-    "iptables": {
-      "query" : "select * from iptables;",
-      "interval" : "3600",
-      "platform" : "linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current filters and chains per filter in the target system.",
-      "value" : "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans"
+    "alf_services": {
+      "description": "Retrieves the services for the Application Layer Firewall in OSX.",
+      "interval": "3600",
+      "platform": "darwin",
+      "query": "select * from alf_services;",
+      "value": "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans",
+      "version": "1.4.5"
     },
     "app_schemes": {
-      "query" : "select * from app_schemes;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.7",
-      "description" : "Retrieves the list of application scheme/protocol-based IPC handlers.",
-      "value" : "Post-priori hijack detection, detect potential sensitive information leakage."
+      "description": "Retrieves the list of application scheme/protocol-based IPC handlers.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from app_schemes;",
+      "value": "Post-priori hijack detection, detect potential sensitive information leakage.",
+      "version": "1.4.7"
+    },
+    "arp_cache": {
+      "description": "Retrieves the ARP cache values in the target system.",
+      "interval": "3600",
+      "query": "select * from arp_cache;",
+      "value": "Determine if MITM in progress.",
+      "version": "1.4.5"
+    },
+    "crontab": {
+      "description": "Retrieves all the jobs scheduled in crontab in the target system.",
+      "interval": "3600",
+      "platform": "posix",
+      "query": "select * from crontab;",
+      "value": "Identify malware that uses this persistence mechanism to launch at a given interval",
+      "version": "1.4.5"
+    },
+    "disk_encryption": {
+      "description": "Retrieves the current disk encryption status for the target system.",
+      "interval": "86400",
+      "platform": "posix",
+      "query": "select * from disk_encryption;",
+      "value": "Identifies a system potentially vulnerable to disk cloning.",
+      "version": "1.4.5"
+    },
+    "etc_hosts": {
+      "description": "Retrieves all the entries in the target system /etc/hosts file.",
+      "interval": "86400",
+      "platform": "posix",
+      "query": "select * from etc_hosts;",
+      "value": "Identify network communications that are being redirected. Example: identify if security logging has been disabled",
+      "version": "1.4.5"
+    },
+    "installed_applications": {
+      "description": "Retrieves all the currently installed applications in the target OSX system.",
+      "interval": "3600",
+      "platform": "darwin",
+      "query": "select * from apps;",
+      "value": "Identify malware, adware, or vulnerable packages that are installed as an application.",
+      "version": "1.4.5"
+    },
+    "ip_forwarding": {
+      "description": "Retrieves the current status of IP/IPv6 forwarding.",
+      "interval": "3600",
+      "platform": "posix",
+      "query": "select * from system_controls where oid = '4.30.41.1' union select * from system_controls where oid = '4.2.0.1';",
+      "value": "Identify if a machine is being used as relay.",
+      "version": "1.4.5"
+    },
+    "iptables": {
+      "description": "Retrieves the current filters and chains per filter in the target system.",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from iptables;",
+      "value": "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans",
+      "version": "1.4.5"
+    },
+    "kernel_modules": {
+      "description": "Retrieves all the information for the current kernel modules in the target Linux system.",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from kernel_modules;",
+      "value": "Identify malware that has a kernel module component.",
+      "version": "1.4.5"
+    },
+    "kextstat": {
+      "description": "Retrieves all the information about the current kernel extensions for the target OSX system.",
+      "interval": "3600",
+      "platform": "darwin",
+      "query": "select * from kernel_extensions;",
+      "value": "Identify malware that has a kernel extension component.",
+      "version": "1.4.5"
+    },
+    "last": {
+      "description": "Retrieves the list of the latest logins with PID, username and timestamp.",
+      "interval": "3600",
+      "platform": "posix",
+      "query": "select * from last;",
+      "value": "Useful for intrusion detection and incident response. Verify assumptions of what accounts should be accessing what systems and identify machines accessed during a compromise.",
+      "version": "1.4.5"
+    },
+    "launchd": {
+      "description": "Retrieves all the daemons that will run in the start of the target OSX system.",
+      "interval": "3600",
+      "platform": "darwin",
+      "query": "select * from launchd;",
+      "value": "Identify malware that uses this persistence mechanism to launch at system boot",
+      "version": "1.4.5"
+    },
+    "listening_ports": {
+      "description": "Retrieves all the listening ports in the target system.",
+      "interval": "3600",
+      "platform": "posix",
+      "query": "select * from listening_ports;",
+      "value": "Detect if a listening port iis not mapped to a known process. Find backdoors.",
+      "version": "1.4.5"
+    },
+    "logged_in_users": {
+      "description": "Retrieves the list of all the currently logged in users in the target system.",
+      "interval": "3600",
+      "platform": "posix",
+      "query": "select liu.*, p.name, p.cmdline, p.cwd, p.root from logged_in_users liu, processes p where liu.pid = p.pid;",
+      "value": "Useful for intrusion detection and incident response. Verify assumptions of what accounts should be accessing what systems and identify machines accessed during a compromise.",
+      "version": "1.4.5"
+    },
+    "loginwindow1": {
+      "description": "Retrieves all the values for the loginwindow process in the target OSX system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select key, subkey, value from plist where path = '/Library/Preferences/com.apple.loginwindow.plist';",
+      "value": "Identify malware that uses this persistence mechanism to launch at system boot",
+      "version": "1.4.5"
+    },
+    "loginwindow2": {
+      "description": "Retrieves all the values for the loginwindow process in the target OSX system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select key, subkey, value from plist where path = '/Library/Preferences/loginwindow.plist';",
+      "value": "Identify malware that uses this persistence mechanism to launch at system boot",
+      "version": "1.4.5"
+    },
+    "loginwindow3": {
+      "description": "Retrieves all the values for the loginwindow process in the target OSX system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select username, key, subkey, value from plist p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/com.apple.loginwindow.plist';",
+      "value": "Identify malware that uses this persistence mechanism to launch at system boot",
+      "version": "1.4.5"
+    },
+    "loginwindow4": {
+      "description": "Retrieves all the values for the loginwindow process in the target OSX system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select username, key, subkey, value from plist p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/loginwindow.plist';",
+      "value": "Identify malware that uses this persistence mechanism to launch at system boot",
+      "version": "1.4.5"
+    },
+    "mounts": {
+      "description": "Retrieves the current list of mounted drives in the target system.",
+      "interval": "3600",
+      "platform": "posix",
+      "query": "select * from mounts;",
+      "value": "Scope for lateral movement. Potential exfiltration locations. Potential dormant backdoors.",
+      "version": "1.4.5"
+    },
+    "nfs_shares": {
+      "description": "Retrieves the current list of Network File System mounted shares.",
+      "interval": "3600",
+      "platform": "darwin",
+      "query": "select * from nfs_shares;",
+      "value": "Scope for lateral movement. Potential exfiltration locations. Potential dormant backdoors.",
+      "version": "1.4.5"
+    },
+    "open_files": {
+      "description": "Retrieves all the open files per process in the target system.",
+      "interval": "86400",
+      "platform": "posix",
+      "query": "select distinct pid, path from process_open_files where path not like '/private/var/folders%' and path not like '/System/Library/%' and path not in ('/dev/null', '/dev/urandom', '/dev/random');",
+      "value": "Identify processes accessing sensitive files they shouldn't",
+      "version": "1.4.5"
+    },
+    "open_sockets": {
+      "description": "Retrieves all the open sockets per process in the target system.",
+      "interval": "86400",
+      "platform": "posix",
+      "query": "select distinct pid, family, protocol, local_address, local_port, remote_address, remote_port, path from process_open_sockets where path <> '' or remote_address <> '';",
+      "value": "Identify malware via connections to known bad IP addresses as well as odd local or remote port bindings",
+      "version": "1.4.5"
+    },
+    "process_env": {
+      "description": "Retrieves all the environment variables per process in the target system.",
+      "interval": "86400",
+      "platform": "posix",
+      "query": "select * from process_envs;",
+      "value": "Insight into the process data: Where was it started from, was it preloaded...",
+      "version": "1.4.5"
+    },
+    "process_memory": {
+      "description": "Retrieves the memory map per process in the target Linux system.",
+      "interval": "86400",
+      "platform": "linux",
+      "query": "select * from process_memory_map;",
+      "value": "Ability to compare with known good. Identify mapped regions corresponding with or containing injected code.",
+      "version": "1.4.5"
+    },
+    "ramdisk": {
+      "description": "Retrieves all the ramdisk currently mounted in the target system.",
+      "interval": "3600",
+      "platform": "posix",
+      "query": "select * from block_devices where type = 'Virtual Interface';",
+      "value": "Identify if an attacker is using temporary, memory storage to avoid touching disk for anti-forensics purposes",
+      "version": "1.4.5"
+    },
+    "recent_items": {
+      "description": "Retrieves the list of recent items opened in OSX by parsing the plist per user.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select username, key, value from plist p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/com.apple.recentitems.plist';",
+      "value": "Identify recently accessed items. Useful for compromised hosts.",
+      "version": "1.4.5"
     },
     "sandboxes": {
-      "query" : "select * from sandboxes;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.7",
-      "description" : "Lists the application bundle that owns a sandbox label.",
-      "value" : "Post-priori hijack detection, detect potential sensitive information leakage."
+      "description": "Lists the application bundle that owns a sandbox label.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from sandboxes;",
+      "value": "Post-priori hijack detection, detect potential sensitive information leakage.",
+      "version": "1.4.7"
+    },
+    "shell_history": {
+      "description": "Retrieves the command history, per user, by parsing the shell history files.",
+      "interval": "86400",
+      "platform": "posix",
+      "query": "select * from users join shell_history using (uid);",
+      "value": "Identify actions taken. Useful for compromised hosts.",
+      "version": "1.4.5"
+    },
+    "startup_items": {
+      "description": "Retrieve all the items that will load when the target OSX system starts.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from startup_items;",
+      "value": "Identify malware that uses this persistence mechanism to launch at a given interval",
+      "version": "1.4.5"
+    },
+    "suid_bin": {
+      "description": "Retrieves all the files in the target system that are setuid enabled.",
+      "interval": "3600",
+      "platform": "posix",
+      "query": "select * from suid_bin;",
+      "value": "Detect backdoor binaries (attacker may drop a copy of /bin/sh). Find potential elevation points / vulnerabilities in the standard build.",
+      "version": "1.4.5"
+    },
+    "wireless_networks": {
+      "description": "Retrieves all the remembered wireless network that the target machine has connected to.",
+      "interval": "3600",
+      "platform": "darwin",
+      "query": "select ssid, network_name, security_type, last_connected, captive_portal, possibly_hidden, roaming, roaming_profile from wifi_networks;",
+      "value": "Identifies connections to rogue access points.",
+      "version": "1.6.0"
     }
   }
 }

--- a/output/packs/it-compliance.conf
+++ b/output/packs/it-compliance.conf
@@ -1,0 +1,252 @@
+{
+  "queries": {
+    "osquery_info": {
+      "query" : "select * from time, osquery_info;",
+      "interval" : "86400",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current version of the running osquery in the target system and where the configuration was loaded from.",
+      "value" : "Identify if your infrastructure is running the correct osquery version and which hosts may have drifted"
+    },
+    "ad_config": {
+      "query" : "select * from ad_config;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the Active Directory configuration for the target machine, attached to the domain (requires sudo).",
+      "value" : "Helps you debug domain binding / Active Directory issues in your environment."
+    },
+    "kernel_info": {
+      "query" : "select * from kernel_info;",
+      "interval" : "86400",
+      "version" : "1.4.5",
+      "description" : "Retrieves information from the current kernel in the target system.",
+      "value" : "Identify out of date kernels or version drift across your infrastructure"
+    },
+    "os_version": {
+      "query" : "select * from os_version;",
+      "interval" : "86400",
+      "version" : "1.4.5",
+      "description" : "Retrieves information from the Operative System where osquery is currently running.",
+      "value" : "Identify out of date operating systems or version drift across your infrastructure"
+    },
+    "alf": {
+      "query" : "select * from alf;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the configuration values for the Application Layer Firewall for OSX.",
+      "value" : "Verify firewall settings are as expected"
+    },
+    "alf_exceptions": {
+      "query" : "select * from alf_exceptions;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the exceptions for the Application Layer Firewall in OSX.",
+      "value" : "Verify firewall settings are as expected"
+    },
+    "alf_services": {
+      "query" : "select * from alf_services;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the services for the Application Layer Firewall in OSX.",
+      "value" : "Verify firewall settings are as expected"
+    },
+    "alf_explicit_auths": {
+      "query" : "select * from alf_explicit_auths;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the list of processes with explicit authorization for the Application Layer Firewall.",
+      "value" : "Verify firewall settings are as expected"
+    },
+    "mounts": {
+      "query" : "select * from mounts;",
+      "interval" : "86400",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current list of mounted drives in the target system.",
+      "value" : "Verify if mounts are accessible to those who need it"
+    },
+    "nfs_shares": {
+      "query" : "select * from nfs_shares;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current list of Network File System mounted shares.",
+      "value" : "Verify if shares are accessible to those who need it"
+    },
+    "windows_shared_resources": {
+      "query" : "select * from shared_resources;",
+      "interval" : "86400",
+      "platform" : "windows",
+      "version" : "2.0.0",
+      "description" : "Retrieves the list of shared resources in the target Windows system.",
+      "value" : "General security posture."
+    },
+    "browser_plugins": {
+      "query" : "select * from users join browser_plugins using (uid);",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the list of C/NPAPI browser plugins in the target system.",
+      "value" : "General security posture."
+    },
+    "safari_extensions": {
+      "query" : "select * from users join safari_extensions using (uid);",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the list of extensions for Safari in the target system.",
+      "value" : "General security posture."
+    },
+    "chrome_extensions": {
+      "query" : "select * from users join chrome_extensions using (uid);",
+      "interval" : "86400",
+      "version" : "1.4.5",
+      "description" : "Retrieves the list of extensions for Chrome in the target system.",
+      "value" : "General security posture."
+    },
+    "firefox_addons": {
+      "query" : "select * from users join firefox_addons using (uid);",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the list of addons for Firefox in the target system.",
+      "value" : "General security posture."
+    },
+    "homebrew_packages": {
+      "query" : "select * from homebrew_packages;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the list of brew packages installed in the target OSX system.",
+      "value" : "General security posture."
+    },
+    "windows_programs": {
+      "query" : "select * from programs;",
+      "interval" : "86400",
+      "platform" : "windows",
+      "version" : "2.0.0",
+      "description" : "Retrieves the list of products as they are installed by Windows Installer in the target Windows system.",
+      "value" : "General security posture."
+    },
+    "windows_patches": {
+      "query" : "select * from patches;",
+      "interval" : "86400",
+      "platform" : "windows",
+      "version" : "2.2.0",
+      "description" : "Retrieves all the information for the current windows drivers in the target Windows system."
+    },
+    "package_receipts": {
+      "query" : "select * from package_receipts;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the PKG related information stored in OSX.",
+      "value" : "General security posture."
+    },
+    "usb_devices": {
+      "query" : "select * from usb_devices;",
+      "interval" : "86400",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current list of USB devices in the target system.",
+      "value" : "General security posture."
+    },
+    "keychain_items": {
+      "query" : "select * from keychain_items;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the items contained in the keychain in the target OSX system.",
+      "value" : "General security posture."
+    },
+    "deb_packages": {
+      "query" : "select * from deb_packages;",
+      "interval" : "86400",
+      "platform" : "ubuntu",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the installed DEB packages in the target Linux system.",
+      "value" : "General security posture."
+    },
+    "apt_sources": {
+      "query" : "select * from apt_sources;",
+      "interval" : "86400",
+      "platform" : "ubuntu",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the APT sources to install packages from in the target Linux system.",
+      "value" : "General security posture."
+    },
+    "portage_packages": {
+      "query" : "select * from portage_use;",
+      "interval" : "86400",
+      "platform" : "gentoo",
+      "version" : "2.0.0",
+      "description" : "Retrieves all the packages installed with portage from the target Linux system.",
+      "value" : "General security posture."
+    },
+    "kernel_modules": {
+      "query" : "select * from kernel_modules;",
+      "interval" : "86400",
+      "platform" : "linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current list of loaded kernel modules in the target Linux system.",
+      "value" : "General security posture."
+    },
+    "windows_drivers": {
+      "query" : "select * from drivers;",
+      "interval" : "86400",
+      "platform" : "windows",
+      "version" : "2.2.0",
+      "description" : "Retrieves all the information for the current windows drivers in the target Windows system."
+    },
+    "rpm_packages": {
+      "query" : "select * from rpm_packages;",
+      "interval" : "86400",
+      "platform" : "linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the installed RPM packages in the target Linux system.",
+      "value" : "General security posture."
+    },
+    "installed_applications": {
+      "query" : "select * from apps;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the currently installed applications in the target OSX system.",
+      "value" : "Find currently installed applications and versions of each."
+    },
+    "disk_encryption": {
+      "query" : "select * from disk_encryption;",
+      "interval" : "86400",
+      "version" : "1.4.5",
+      "platform" : "posix",
+      "description" : "Retrieves the current disk encryption status for the target system.",
+      "value" : "Identifies a system potentially vulnerable to disk cloning."
+    },
+    "launchd": {
+      "query" : "select * from launchd;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the daemons that will run in the start of the target OSX system.",
+      "value" : "Visibility on what starts in the system."
+    },
+    "iptables": {
+      "query" : "select * from iptables;",
+      "interval" : "86400",
+      "platform" : "linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current filters and chains per filter in the target system.",
+      "value" : "General security posture."
+    },
+    "sip_config": {
+      "query" : "select * from sip_config;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.7.0",
+      "description" : "Retrieves the current System Integrity Protection configuration in the target system.",
+      "value" : "General security posture."
+    }
+  }
+}

--- a/output/packs/it-compliance.conf
+++ b/output/packs/it-compliance.conf
@@ -1,252 +1,252 @@
 {
   "queries": {
-    "osquery_info": {
-      "query" : "select * from time, osquery_info;",
-      "interval" : "86400",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current version of the running osquery in the target system and where the configuration was loaded from.",
-      "value" : "Identify if your infrastructure is running the correct osquery version and which hosts may have drifted"
-    },
     "ad_config": {
-      "query" : "select * from ad_config;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the Active Directory configuration for the target machine, attached to the domain (requires sudo).",
-      "value" : "Helps you debug domain binding / Active Directory issues in your environment."
-    },
-    "kernel_info": {
-      "query" : "select * from kernel_info;",
-      "interval" : "86400",
-      "version" : "1.4.5",
-      "description" : "Retrieves information from the current kernel in the target system.",
-      "value" : "Identify out of date kernels or version drift across your infrastructure"
-    },
-    "os_version": {
-      "query" : "select * from os_version;",
-      "interval" : "86400",
-      "version" : "1.4.5",
-      "description" : "Retrieves information from the Operative System where osquery is currently running.",
-      "value" : "Identify out of date operating systems or version drift across your infrastructure"
+      "description": "Retrieves the Active Directory configuration for the target machine, attached to the domain (requires sudo).",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from ad_config;",
+      "value": "Helps you debug domain binding / Active Directory issues in your environment.",
+      "version": "1.4.5"
     },
     "alf": {
-      "query" : "select * from alf;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the configuration values for the Application Layer Firewall for OSX.",
-      "value" : "Verify firewall settings are as expected"
+      "description": "Retrieves the configuration values for the Application Layer Firewall for OSX.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from alf;",
+      "value": "Verify firewall settings are as expected",
+      "version": "1.4.5"
     },
     "alf_exceptions": {
-      "query" : "select * from alf_exceptions;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the exceptions for the Application Layer Firewall in OSX.",
-      "value" : "Verify firewall settings are as expected"
-    },
-    "alf_services": {
-      "query" : "select * from alf_services;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the services for the Application Layer Firewall in OSX.",
-      "value" : "Verify firewall settings are as expected"
+      "description": "Retrieves the exceptions for the Application Layer Firewall in OSX.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from alf_exceptions;",
+      "value": "Verify firewall settings are as expected",
+      "version": "1.4.5"
     },
     "alf_explicit_auths": {
-      "query" : "select * from alf_explicit_auths;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the list of processes with explicit authorization for the Application Layer Firewall.",
-      "value" : "Verify firewall settings are as expected"
+      "description": "Retrieves the list of processes with explicit authorization for the Application Layer Firewall.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from alf_explicit_auths;",
+      "value": "Verify firewall settings are as expected",
+      "version": "1.4.5"
     },
-    "mounts": {
-      "query" : "select * from mounts;",
-      "interval" : "86400",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current list of mounted drives in the target system.",
-      "value" : "Verify if mounts are accessible to those who need it"
-    },
-    "nfs_shares": {
-      "query" : "select * from nfs_shares;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current list of Network File System mounted shares.",
-      "value" : "Verify if shares are accessible to those who need it"
-    },
-    "windows_shared_resources": {
-      "query" : "select * from shared_resources;",
-      "interval" : "86400",
-      "platform" : "windows",
-      "version" : "2.0.0",
-      "description" : "Retrieves the list of shared resources in the target Windows system.",
-      "value" : "General security posture."
-    },
-    "browser_plugins": {
-      "query" : "select * from users join browser_plugins using (uid);",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the list of C/NPAPI browser plugins in the target system.",
-      "value" : "General security posture."
-    },
-    "safari_extensions": {
-      "query" : "select * from users join safari_extensions using (uid);",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the list of extensions for Safari in the target system.",
-      "value" : "General security posture."
-    },
-    "chrome_extensions": {
-      "query" : "select * from users join chrome_extensions using (uid);",
-      "interval" : "86400",
-      "version" : "1.4.5",
-      "description" : "Retrieves the list of extensions for Chrome in the target system.",
-      "value" : "General security posture."
-    },
-    "firefox_addons": {
-      "query" : "select * from users join firefox_addons using (uid);",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the list of addons for Firefox in the target system.",
-      "value" : "General security posture."
-    },
-    "homebrew_packages": {
-      "query" : "select * from homebrew_packages;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the list of brew packages installed in the target OSX system.",
-      "value" : "General security posture."
-    },
-    "windows_programs": {
-      "query" : "select * from programs;",
-      "interval" : "86400",
-      "platform" : "windows",
-      "version" : "2.0.0",
-      "description" : "Retrieves the list of products as they are installed by Windows Installer in the target Windows system.",
-      "value" : "General security posture."
-    },
-    "windows_patches": {
-      "query" : "select * from patches;",
-      "interval" : "86400",
-      "platform" : "windows",
-      "version" : "2.2.0",
-      "description" : "Retrieves all the information for the current windows drivers in the target Windows system."
-    },
-    "package_receipts": {
-      "query" : "select * from package_receipts;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the PKG related information stored in OSX.",
-      "value" : "General security posture."
-    },
-    "usb_devices": {
-      "query" : "select * from usb_devices;",
-      "interval" : "86400",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current list of USB devices in the target system.",
-      "value" : "General security posture."
-    },
-    "keychain_items": {
-      "query" : "select * from keychain_items;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the items contained in the keychain in the target OSX system.",
-      "value" : "General security posture."
-    },
-    "deb_packages": {
-      "query" : "select * from deb_packages;",
-      "interval" : "86400",
-      "platform" : "ubuntu",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the installed DEB packages in the target Linux system.",
-      "value" : "General security posture."
+    "alf_services": {
+      "description": "Retrieves the services for the Application Layer Firewall in OSX.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from alf_services;",
+      "value": "Verify firewall settings are as expected",
+      "version": "1.4.5"
     },
     "apt_sources": {
-      "query" : "select * from apt_sources;",
-      "interval" : "86400",
-      "platform" : "ubuntu",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the APT sources to install packages from in the target Linux system.",
-      "value" : "General security posture."
+      "description": "Retrieves all the APT sources to install packages from in the target Linux system.",
+      "interval": "86400",
+      "platform": "ubuntu",
+      "query": "select * from apt_sources;",
+      "value": "General security posture.",
+      "version": "1.4.5"
     },
-    "portage_packages": {
-      "query" : "select * from portage_use;",
-      "interval" : "86400",
-      "platform" : "gentoo",
-      "version" : "2.0.0",
-      "description" : "Retrieves all the packages installed with portage from the target Linux system.",
-      "value" : "General security posture."
+    "browser_plugins": {
+      "description": "Retrieves the list of C/NPAPI browser plugins in the target system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from users join browser_plugins using (uid);",
+      "value": "General security posture.",
+      "version": "1.4.5"
     },
-    "kernel_modules": {
-      "query" : "select * from kernel_modules;",
-      "interval" : "86400",
-      "platform" : "linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current list of loaded kernel modules in the target Linux system.",
-      "value" : "General security posture."
+    "chrome_extensions": {
+      "description": "Retrieves the list of extensions for Chrome in the target system.",
+      "interval": "86400",
+      "query": "select * from users join chrome_extensions using (uid);",
+      "value": "General security posture.",
+      "version": "1.4.5"
     },
-    "windows_drivers": {
-      "query" : "select * from drivers;",
-      "interval" : "86400",
-      "platform" : "windows",
-      "version" : "2.2.0",
-      "description" : "Retrieves all the information for the current windows drivers in the target Windows system."
-    },
-    "rpm_packages": {
-      "query" : "select * from rpm_packages;",
-      "interval" : "86400",
-      "platform" : "linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the installed RPM packages in the target Linux system.",
-      "value" : "General security posture."
-    },
-    "installed_applications": {
-      "query" : "select * from apps;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the currently installed applications in the target OSX system.",
-      "value" : "Find currently installed applications and versions of each."
+    "deb_packages": {
+      "description": "Retrieves all the installed DEB packages in the target Linux system.",
+      "interval": "86400",
+      "platform": "ubuntu",
+      "query": "select * from deb_packages;",
+      "value": "General security posture.",
+      "version": "1.4.5"
     },
     "disk_encryption": {
-      "query" : "select * from disk_encryption;",
-      "interval" : "86400",
-      "version" : "1.4.5",
-      "platform" : "posix",
-      "description" : "Retrieves the current disk encryption status for the target system.",
-      "value" : "Identifies a system potentially vulnerable to disk cloning."
+      "description": "Retrieves the current disk encryption status for the target system.",
+      "interval": "86400",
+      "platform": "posix",
+      "query": "select * from disk_encryption;",
+      "value": "Identifies a system potentially vulnerable to disk cloning.",
+      "version": "1.4.5"
     },
-    "launchd": {
-      "query" : "select * from launchd;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the daemons that will run in the start of the target OSX system.",
-      "value" : "Visibility on what starts in the system."
+    "firefox_addons": {
+      "description": "Retrieves the list of addons for Firefox in the target system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from users join firefox_addons using (uid);",
+      "value": "General security posture.",
+      "version": "1.4.5"
+    },
+    "homebrew_packages": {
+      "description": "Retrieves the list of brew packages installed in the target OSX system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from homebrew_packages;",
+      "value": "General security posture.",
+      "version": "1.4.5"
+    },
+    "installed_applications": {
+      "description": "Retrieves all the currently installed applications in the target OSX system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from apps;",
+      "value": "Find currently installed applications and versions of each.",
+      "version": "1.4.5"
     },
     "iptables": {
-      "query" : "select * from iptables;",
-      "interval" : "86400",
-      "platform" : "linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current filters and chains per filter in the target system.",
-      "value" : "General security posture."
+      "description": "Retrieves the current filters and chains per filter in the target system.",
+      "interval": "86400",
+      "platform": "linux",
+      "query": "select * from iptables;",
+      "value": "General security posture.",
+      "version": "1.4.5"
+    },
+    "kernel_info": {
+      "description": "Retrieves information from the current kernel in the target system.",
+      "interval": "86400",
+      "query": "select * from kernel_info;",
+      "value": "Identify out of date kernels or version drift across your infrastructure",
+      "version": "1.4.5"
+    },
+    "kernel_modules": {
+      "description": "Retrieves the current list of loaded kernel modules in the target Linux system.",
+      "interval": "86400",
+      "platform": "linux",
+      "query": "select * from kernel_modules;",
+      "value": "General security posture.",
+      "version": "1.4.5"
+    },
+    "keychain_items": {
+      "description": "Retrieves all the items contained in the keychain in the target OSX system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from keychain_items;",
+      "value": "General security posture.",
+      "version": "1.4.5"
+    },
+    "launchd": {
+      "description": "Retrieves all the daemons that will run in the start of the target OSX system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from launchd;",
+      "value": "Visibility on what starts in the system.",
+      "version": "1.4.5"
+    },
+    "mounts": {
+      "description": "Retrieves the current list of mounted drives in the target system.",
+      "interval": "86400",
+      "query": "select * from mounts;",
+      "value": "Verify if mounts are accessible to those who need it",
+      "version": "1.4.5"
+    },
+    "nfs_shares": {
+      "description": "Retrieves the current list of Network File System mounted shares.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from nfs_shares;",
+      "value": "Verify if shares are accessible to those who need it",
+      "version": "1.4.5"
+    },
+    "os_version": {
+      "description": "Retrieves information from the Operative System where osquery is currently running.",
+      "interval": "86400",
+      "query": "select * from os_version;",
+      "value": "Identify out of date operating systems or version drift across your infrastructure",
+      "version": "1.4.5"
+    },
+    "osquery_info": {
+      "description": "Retrieves the current version of the running osquery in the target system and where the configuration was loaded from.",
+      "interval": "86400",
+      "query": "select * from time, osquery_info;",
+      "value": "Identify if your infrastructure is running the correct osquery version and which hosts may have drifted",
+      "version": "1.4.5"
+    },
+    "package_receipts": {
+      "description": "Retrieves all the PKG related information stored in OSX.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from package_receipts;",
+      "value": "General security posture.",
+      "version": "1.4.5"
+    },
+    "portage_packages": {
+      "description": "Retrieves all the packages installed with portage from the target Linux system.",
+      "interval": "86400",
+      "platform": "gentoo",
+      "query": "select * from portage_use;",
+      "value": "General security posture.",
+      "version": "2.0.0"
+    },
+    "rpm_packages": {
+      "description": "Retrieves all the installed RPM packages in the target Linux system.",
+      "interval": "86400",
+      "platform": "linux",
+      "query": "select * from rpm_packages;",
+      "value": "General security posture.",
+      "version": "1.4.5"
+    },
+    "safari_extensions": {
+      "description": "Retrieves the list of extensions for Safari in the target system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from users join safari_extensions using (uid);",
+      "value": "General security posture.",
+      "version": "1.4.5"
     },
     "sip_config": {
-      "query" : "select * from sip_config;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.7.0",
-      "description" : "Retrieves the current System Integrity Protection configuration in the target system.",
-      "value" : "General security posture."
+      "description": "Retrieves the current System Integrity Protection configuration in the target system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from sip_config;",
+      "value": "General security posture.",
+      "version": "1.7.0"
+    },
+    "usb_devices": {
+      "description": "Retrieves the current list of USB devices in the target system.",
+      "interval": "86400",
+      "query": "select * from usb_devices;",
+      "value": "General security posture.",
+      "version": "1.4.5"
+    },
+    "windows_drivers": {
+      "description": "Retrieves all the information for the current windows drivers in the target Windows system.",
+      "interval": "86400",
+      "platform": "windows",
+      "query": "select * from drivers;",
+      "version": "2.2.0"
+    },
+    "windows_patches": {
+      "description": "Retrieves all the information for the current windows drivers in the target Windows system.",
+      "interval": "86400",
+      "platform": "windows",
+      "query": "select * from patches;",
+      "version": "2.2.0"
+    },
+    "windows_programs": {
+      "description": "Retrieves the list of products as they are installed by Windows Installer in the target Windows system.",
+      "interval": "86400",
+      "platform": "windows",
+      "query": "select * from programs;",
+      "value": "General security posture.",
+      "version": "2.0.0"
+    },
+    "windows_shared_resources": {
+      "description": "Retrieves the list of shared resources in the target Windows system.",
+      "interval": "86400",
+      "platform": "windows",
+      "query": "select * from shared_resources;",
+      "value": "General security posture.",
+      "version": "2.0.0"
     }
   }
 }

--- a/output/packs/osquery-monitoring.conf
+++ b/output/packs/osquery-monitoring.conf
@@ -1,0 +1,28 @@
+{
+  "queries": {
+    "schedule": {
+      "query": "select name, interval, executions, output_size, wall_time, (user_time/executions) as avg_user_time, (system_time/executions) as avg_system_time, average_memory, last_executed from osquery_schedule;",
+      "interval": 7200,
+      "removed": false,
+      "blacklist": false,
+      "version": "1.6.0",
+      "description": "Report performance for every query within packs and the general schedule."
+    },
+    "events": {
+      "query": "select name, publisher, type, subscriptions, events, active from osquery_events;",
+      "interval": 86400,
+      "removed": false,
+      "blacklist": false,
+      "version": "1.5.3",
+      "description": "Report event publisher health and track event counters."
+    },
+    "osquery_info": {
+      "query": "select i.*, p.resident_size, p.user_time, p.system_time, time.minutes as counter from osquery_info i, processes p, time where p.pid = i.pid;",
+      "interval": 600,
+      "removed": false,
+      "blacklist": false,
+      "version": "1.2.2",
+      "description": "A heartbeat counter that reports general performance (CPU, memory) and version."
+    }
+  }
+}

--- a/output/packs/osquery-monitoring.conf
+++ b/output/packs/osquery-monitoring.conf
@@ -1,28 +1,28 @@
 {
   "queries": {
-    "schedule": {
-      "query": "select name, interval, executions, output_size, wall_time, (user_time/executions) as avg_user_time, (system_time/executions) as avg_system_time, average_memory, last_executed from osquery_schedule;",
-      "interval": 7200,
-      "removed": false,
-      "blacklist": false,
-      "version": "1.6.0",
-      "description": "Report performance for every query within packs and the general schedule."
-    },
     "events": {
-      "query": "select name, publisher, type, subscriptions, events, active from osquery_events;",
-      "interval": 86400,
-      "removed": false,
       "blacklist": false,
-      "version": "1.5.3",
-      "description": "Report event publisher health and track event counters."
+      "description": "Report event publisher health and track event counters.",
+      "interval": 86400,
+      "query": "select name, publisher, type, subscriptions, events, active from osquery_events;",
+      "removed": false,
+      "version": "1.5.3"
     },
     "osquery_info": {
-      "query": "select i.*, p.resident_size, p.user_time, p.system_time, time.minutes as counter from osquery_info i, processes p, time where p.pid = i.pid;",
-      "interval": 600,
-      "removed": false,
       "blacklist": false,
-      "version": "1.2.2",
-      "description": "A heartbeat counter that reports general performance (CPU, memory) and version."
+      "description": "A heartbeat counter that reports general performance (CPU, memory) and version.",
+      "interval": 600,
+      "query": "select i.*, p.resident_size, p.user_time, p.system_time, time.minutes as counter from osquery_info i, processes p, time where p.pid = i.pid;",
+      "removed": false,
+      "version": "1.2.2"
+    },
+    "schedule": {
+      "blacklist": false,
+      "description": "Report performance for every query within packs and the general schedule.",
+      "interval": 7200,
+      "query": "select name, interval, executions, output_size, wall_time, (user_time/executions) as avg_user_time, (system_time/executions) as avg_system_time, average_memory, last_executed from osquery_schedule;",
+      "removed": false,
+      "version": "1.6.0"
     }
   }
 }

--- a/output/packs/ossec-rootkit.conf
+++ b/output/packs/ossec-rootkit.conf
@@ -1,0 +1,412 @@
+{
+  "platform": "linux", 
+  "version": "1.4.5", 
+  "queries": {
+    "bash_door": {
+      "query": "select * from file where path in ('/tmp/mcliZokhb', '/tmp/mclzaKmfa');", 
+      "interval": "3600", 
+      "description": "bash_door", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "slapper_installed": {
+      "query": "select * from file where path in ('/tmp/.bugtraq', '/tmp/.bugtraq.c', '/tmp/.cinik', '/tmp/.b', '/tmp/httpd', '/tmp./update', '/tmp/.unlock', '/tmp/.font-unix/.cinik', '/tmp/.cinik');", 
+      "interval": "3600", 
+      "description": "slapper_installed", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "mithra`s_rootkit": {
+      "query": "select * from file where path in ('/usr/lib/locale/uboot');", 
+      "interval": "3600", 
+      "description": "mithra`s_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "omega_worm": {
+      "query": "select * from file where path in ('/dev/chr');", 
+      "interval": "3600", 
+      "description": "omega_worm", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "kenga3_rootkit": {
+      "query": "select * from file where path in ('/usr/include/. .');", 
+      "interval": "3600", 
+      "description": "kenga3_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "sadmind/iis_worm": {
+      "query": "select * from file where path in ('/dev/cuc');", 
+      "interval": "3600", 
+      "description": "sadmind/iis_worm", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "rsha": {
+      "query": "select * from file where path in ('/usr/bin/kr4p', '/usr/bin/n3tstat', '/usr/bin/chsh2', '/usr/bin/slice2', '/etc/rc.d/rsha');", 
+      "interval": "3600", 
+      "description": "rsha", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "old_rootkits": {
+      "query": "select * from file where path in ('/usr/include/rpc/ ../kit', '/usr/include/rpc/ ../kit2', '/usr/doc/.sl', '/usr/doc/.sp', '/usr/doc/.statnet', '/usr/doc/.logdsys', '/usr/doc/.dpct', '/usr/doc/.gifnocfi', '/usr/doc/.dnif', '/usr/doc/.nigol');", 
+      "interval": "3600", 
+      "description": "old_rootkits", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "telekit_trojan": {
+      "query": "select * from file where path in ('/dev/hda06', '/usr/info/libc1.so');", 
+      "interval": "3600", 
+      "description": "telekit_trojan", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "tc2_worm": {
+      "query": "select * from file where path in ('/usr/info/.tc2k', '/usr/bin/util', '/usr/sbin/initcheck', '/usr/sbin/ldb');", 
+      "interval": "3600", 
+      "description": "tc2_worm", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "shitc": {
+      "query": "select * from file where path in ('/bin/home', '/sbin/home', '/usr/sbin/in.slogind');", 
+      "interval": "3600", 
+      "description": "shitc", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "rh_sharpe": {
+      "query": "select * from file where path in ('/bin/.ps', '/usr/bin/cleaner', '/usr/bin/slice', '/usr/bin/vadim', '/usr/bin/.ps', '/bin/.lpstree', '/usr/bin/.lpstree', '/usr/bin/lnetstat', '/bin/lnetstat', '/usr/bin/ldu', '/bin/ldu', '/usr/bin/lkillall', '/bin/lkillall', '/usr/include/rpcsvc/du');", 
+      "interval": "3600", 
+      "description": "rh_sharpe", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "showtee_/_romanian_rootkit": {
+      "query": "select * from file where path in ('/usr/include/addr.h', '/usr/include/file.h', '/usr/include/syslogs.h', '/usr/include/proc.h');", 
+      "interval": "3600", 
+      "description": "showtee_/_romanian_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "lrk_rootkit": {
+      "query": "select * from file where path in ('/dev/ida/.inet');", 
+      "interval": "3600", 
+      "description": "lrk_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "zk_rootkit": {
+      "query": "select * from file where path in ('/usr/share/.zk', '/usr/share/.zk/zk', '/etc/1ssue.net', '/usr/X11R6/.zk', '/usr/X11R6/.zk/xfs', '/usr/X11R6/.zk/echo', '/etc/sysconfig/console/load.zk');", 
+      "interval": "3600", 
+      "description": "zk_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "ramen_worm": {
+      "query": "select * from file where path in ('/usr/lib/ldlibps.so', '/usr/lib/ldlibns.so', '/usr/lib/ldliblogin.so', '/usr/src/.poop', '/tmp/ramen.tgz', '/etc/xinetd.d/asp');", 
+      "interval": "3600", 
+      "description": "ramen_worm", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "maniac_rk": {
+      "query": "select * from file where path in ('/usr/bin/mailrc');", 
+      "interval": "3600", 
+      "description": "maniac_rk", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "bmbl_rootkit": {
+      "query": "select * from file where path in ('/etc/.bmbl', '/etc/.bmbl/sk');", 
+      "interval": "3600", 
+      "description": "bmbl_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "suckit_rootkit": {
+      "query": "select * from file where path in ('/lib/.x', '/lib/sk');", 
+      "interval": "3600", 
+      "description": "suckit_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "adore_rootkit": {
+      "query": "select * from file where path in ('/etc/bin/ava', '/etc/sbin/ava');", 
+      "interval": "3600", 
+      "description": "adore_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "ldp_worm": {
+      "query": "select * from file where path in ('/dev/.kork', '/bin/.login', '/bin/.ps');", 
+      "interval": "3600", 
+      "description": "ldp_worm", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "romanian_rootkit": {
+      "query": "select * from file where path in ('/usr/sbin/initdl', '/usr/sbin/xntps');", 
+      "interval": "3600", 
+      "description": "romanian_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "illogic_rootkit": {
+      "query": "select * from file where path in ('/lib/security/.config', '/usr/bin/sia', '/etc/ld.so.hash');", 
+      "interval": "3600", 
+      "description": "illogic_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "bobkit_rootkit": {
+      "query": "select * from file where path in ('/usr/include/.../', '/usr/lib/.../', '/usr/sbin/.../', '/usr/bin/ntpsx', '/tmp/.bkp', '/usr/lib/.bkit-');", 
+      "interval": "3600", 
+      "description": "bobkit_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "monkit": {
+      "query": "select * from file where path in ('/lib/defs');", 
+      "interval": "3600", 
+      "description": "monkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "override_rootkit": {
+      "query": "select * from file where path in ('/dev/grid-hide-pid-', '/dev/grid-unhide-pid-', '/dev/grid-show-pids', '/dev/grid-hide-port-', '/dev/grid-unhide-port-');", 
+      "interval": "3600", 
+      "description": "override_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "madalin_rootkit": {
+      "query": "select * from file where path in ('/usr/include/icekey.h', '/usr/include/iceconf.h', '/usr/include/iceseed.h');", 
+      "interval": "3600", 
+      "description": "madalin_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "solaris_worm": {
+      "query": "select * from file where path in ('/var/adm/.profile', '/var/spool/lp/.profile', '/var/adm/sa/.adm', '/var/spool/lp/admins/.lp');", 
+      "interval": "3600", 
+      "description": "solaris_worm", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "phalanx_rootkit": {
+      "query": "select * from file where path in ('/usr/share/.home*', '/usr/share/.home*/tty', '/etc/host.ph1', '/bin/host.ph1');", 
+      "interval": "3600", 
+      "description": "phalanx_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "ark_rootkit": {
+      "query": "select * from file where path in ('/dev/ptyxx');", 
+      "interval": "3600", 
+      "description": "ark_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "tribe_bot": {
+      "query": "select * from file where path in ('/dev/wd4');", 
+      "interval": "3600", 
+      "description": "tribe_bot", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "cback_worm": {
+      "query": "select * from file where path in ('/tmp/cback', '/tmp/derfiq');", 
+      "interval": "3600", 
+      "description": "cback_worm", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "optickit": {
+      "query": "select * from file where path in ('/usr/bin/xchk', '/usr/bin/xsf', '/usr/bin/xsf', '/usr/bin/xchk');", 
+      "interval": "3600", 
+      "description": "optickit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "anonoiyng_rootkit": {
+      "query": "select * from file where path in ('/usr/sbin/mech', '/usr/sbin/kswapd');", 
+      "interval": "3600", 
+      "description": "anonoiyng_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "loc_rookit": {
+      "query": "select * from file where path in ('/tmp/xp', '/tmp/kidd0.c', '/tmp/kidd0');", 
+      "interval": "3600", 
+      "description": "loc_rookit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "showtee": {
+      "query": "select * from file where path in ('/usr/lib/.egcs', '/usr/lib/.wormie', '/usr/lib/.kinetic', '/usr/lib/liblog.o', '/usr/include/cron.h', '/usr/include/chk.h');", 
+      "interval": "3600", 
+      "description": "showtee", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "zarwt_rootkit": {
+      "query": "select * from file where path in ('/bin/imin', '/bin/imout');", 
+      "interval": "3600", 
+      "description": "zarwt_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "lion_worm": {
+      "query": "select * from file where path in ('/dev/.lib', '/dev/.lib/1iOn.sh', '/bin/mjy', '/bin/in.telnetd', '/usr/info/torn');", 
+      "interval": "3600", 
+      "description": "lion_worm", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "suspicious_file": {
+      "query": "select * from file where path in ('/etc/rc.d/init.d/rc.modules', '/lib/ldd.so', '/usr/man/muie', '/usr/X11R6/include/pain', '/usr/bin/sourcemask', '/usr/bin/ras2xm', '/usr/bin/ddc', '/usr/bin/jdc', '/usr/sbin/in.telnet', '/sbin/vobiscum', '/usr/sbin/jcd', '/usr/sbin/atd2', '/usr/bin/ishit', '/usr/bin/.etc', '/usr/bin/xstat', '/var/run/.tmp', '/usr/man/man1/lib/.lib', '/usr/man/man2/.man8', '/var/run/.pid', '/lib/.so', '/lib/.fx', '/lib/lblip.tk', '/usr/lib/.fx', '/var/local/.lpd', '/dev/rd/cdb', '/dev/.rd/', '/usr/lib/pt07', '/usr/bin/atm', '/tmp/.cheese', '/dev/.arctic', '/dev/.xman', '/dev/.golf', '/dev/srd0', '/dev/ptyzx', '/dev/ptyzg', '/dev/xdf1', '/dev/ttyop', '/dev/ttyof', '/dev/hd7', '/dev/hdx1', '/dev/hdx2', '/dev/xdf2', '/dev/ptyp', '/dev/ptyr', '/sbin/pback', '/usr/man/man3/psid', '/proc/kset', '/usr/bin/gib', '/usr/bin/snick', '/usr/bin/kfl', '/tmp/.dump', '/var/.x', '/var/.x/psotnic');", 
+      "interval": "3600", 
+      "description": "suspicious_file", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "apa_kit": {
+      "query": "select * from file where path in ('/usr/share/.aPa');", 
+      "interval": "3600", 
+      "description": "apa_kit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "enye_sec_rootkit": {
+      "query": "select * from file where path in ('/etc/.enyelkmHIDE^IT.ko');", 
+      "interval": "3600", 
+      "description": "enye_sec_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "rk17": {
+      "query": "select * from file where path in ('/bin/rtty', '/bin/squit', '/sbin/pback', '/proc/kset', '/usr/src/linux/modules/autod.o', '/usr/src/linux/modules/soundx.o');", 
+      "interval": "3600", 
+      "description": "rk17", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "trk_rootkit": {
+      "query": "select * from file where path in ('/usr/bin/soucemask', '/usr/bin/sourcemask');", 
+      "interval": "3600", 
+      "description": "trk_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "scalper_installed": {
+      "query": "select * from file where path in ('/tmp/.uua', '/tmp/.a');", 
+      "interval": "3600", 
+      "description": "scalper_installed", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "hidr00tkit": {
+      "query": "select * from file where path in ('/var/lib/games/.k');", 
+      "interval": "3600", 
+      "description": "hidr00tkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "beastkit_rootkit": {
+      "query": "select * from file where path in ('/usr/local/bin/bin', '/usr/man/.man10', '/usr/sbin/arobia', '/usr/lib/elm/arobia', '/usr/local/bin/.../bktd');", 
+      "interval": "3600", 
+      "description": "beastkit_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "shv5_rootkit": {
+      "query": "select * from file where path in ('/lib/libsh.so', '/usr/lib/libsh');", 
+      "interval": "3600", 
+      "description": "shv5_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "esrk_rootkit": {
+      "query": "select * from file where path in ('/usr/lib/tcl5.3');", 
+      "interval": "3600", 
+      "description": "esrk_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "shkit_rootkit": {
+      "query": "select * from file where path in ('/lib/security/.config', '/etc/ld.so.hash');", 
+      "interval": "3600", 
+      "description": "shkit_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "knark_installed": {
+      "query": "select * from file where path in ('/proc/knark', '/dev/.pizda', '/dev/.pula', '/dev/.pula');", 
+      "interval": "3600", 
+      "description": "knark_installed", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "volc_rootkit": {
+      "query": "select * from file where path in ('/usr/lib/volc', '/usr/bin/volc');", 
+      "interval": "3600", 
+      "description": "volc_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "fu_rootkit": {
+      "query": "select * from file where path in ('/sbin/xc', '/usr/include/ivtype.h', '/bin/.lib');", 
+      "interval": "3600", 
+      "description": "fu_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "ajakit_rootkit": {
+      "query": "select * from file where path in ('/lib/.ligh.gh', '/lib/.libgh.gh', '/lib/.libgh-gh', '/dev/tux', '/dev/tux/.proc', '/dev/tux/.file');", 
+      "interval": "3600", 
+      "description": "ajakit_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "monkit_found": {
+      "query": "select * from file where path in ('/usr/lib/libpikapp.a');", 
+      "interval": "3600", 
+      "description": "monkit_found", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "t0rn_rootkit": {
+      "query": "select * from file where path in ('/usr/src/.puta', '/usr/info/.t0rn', '/lib/ldlib.tk', '/etc/ttyhash', '/sbin/xlogin');", 
+      "interval": "3600", 
+      "description": "t0rn_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "adore_worm": {
+      "query": "select * from file where path in ('/dev/.shit/red.tgz', '/usr/lib/libt', '/usr/bin/adore');", 
+      "interval": "3600", 
+      "description": "adore_worm", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "55808.a_worm": {
+      "query": "select * from file where path in ('/tmp/.../a', '/tmp/.../r');", 
+      "interval": "3600", 
+      "description": "55808.a_worm", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }, 
+    "tuxkit_rootkit": {
+      "query": "select * from file where path in ('/dev/tux', '/usr/bin/xsf', '/usr/bin/xchk');", 
+      "interval": "3600", 
+      "description": "tuxkit_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }
+  }
+}

--- a/output/packs/ossec-rootkit.conf
+++ b/output/packs/ossec-rootkit.conf
@@ -1,412 +1,412 @@
 {
-  "platform": "linux", 
-  "version": "1.4.5", 
+  "platform": "linux",
   "queries": {
-    "bash_door": {
-      "query": "select * from file where path in ('/tmp/mcliZokhb', '/tmp/mclzaKmfa');", 
-      "interval": "3600", 
-      "description": "bash_door", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "slapper_installed": {
-      "query": "select * from file where path in ('/tmp/.bugtraq', '/tmp/.bugtraq.c', '/tmp/.cinik', '/tmp/.b', '/tmp/httpd', '/tmp./update', '/tmp/.unlock', '/tmp/.font-unix/.cinik', '/tmp/.cinik');", 
-      "interval": "3600", 
-      "description": "slapper_installed", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "mithra`s_rootkit": {
-      "query": "select * from file where path in ('/usr/lib/locale/uboot');", 
-      "interval": "3600", 
-      "description": "mithra`s_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "omega_worm": {
-      "query": "select * from file where path in ('/dev/chr');", 
-      "interval": "3600", 
-      "description": "omega_worm", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "kenga3_rootkit": {
-      "query": "select * from file where path in ('/usr/include/. .');", 
-      "interval": "3600", 
-      "description": "kenga3_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "sadmind/iis_worm": {
-      "query": "select * from file where path in ('/dev/cuc');", 
-      "interval": "3600", 
-      "description": "sadmind/iis_worm", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "rsha": {
-      "query": "select * from file where path in ('/usr/bin/kr4p', '/usr/bin/n3tstat', '/usr/bin/chsh2', '/usr/bin/slice2', '/etc/rc.d/rsha');", 
-      "interval": "3600", 
-      "description": "rsha", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "old_rootkits": {
-      "query": "select * from file where path in ('/usr/include/rpc/ ../kit', '/usr/include/rpc/ ../kit2', '/usr/doc/.sl', '/usr/doc/.sp', '/usr/doc/.statnet', '/usr/doc/.logdsys', '/usr/doc/.dpct', '/usr/doc/.gifnocfi', '/usr/doc/.dnif', '/usr/doc/.nigol');", 
-      "interval": "3600", 
-      "description": "old_rootkits", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "telekit_trojan": {
-      "query": "select * from file where path in ('/dev/hda06', '/usr/info/libc1.so');", 
-      "interval": "3600", 
-      "description": "telekit_trojan", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "tc2_worm": {
-      "query": "select * from file where path in ('/usr/info/.tc2k', '/usr/bin/util', '/usr/sbin/initcheck', '/usr/sbin/ldb');", 
-      "interval": "3600", 
-      "description": "tc2_worm", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "shitc": {
-      "query": "select * from file where path in ('/bin/home', '/sbin/home', '/usr/sbin/in.slogind');", 
-      "interval": "3600", 
-      "description": "shitc", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "rh_sharpe": {
-      "query": "select * from file where path in ('/bin/.ps', '/usr/bin/cleaner', '/usr/bin/slice', '/usr/bin/vadim', '/usr/bin/.ps', '/bin/.lpstree', '/usr/bin/.lpstree', '/usr/bin/lnetstat', '/bin/lnetstat', '/usr/bin/ldu', '/bin/ldu', '/usr/bin/lkillall', '/bin/lkillall', '/usr/include/rpcsvc/du');", 
-      "interval": "3600", 
-      "description": "rh_sharpe", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "showtee_/_romanian_rootkit": {
-      "query": "select * from file where path in ('/usr/include/addr.h', '/usr/include/file.h', '/usr/include/syslogs.h', '/usr/include/proc.h');", 
-      "interval": "3600", 
-      "description": "showtee_/_romanian_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "lrk_rootkit": {
-      "query": "select * from file where path in ('/dev/ida/.inet');", 
-      "interval": "3600", 
-      "description": "lrk_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "zk_rootkit": {
-      "query": "select * from file where path in ('/usr/share/.zk', '/usr/share/.zk/zk', '/etc/1ssue.net', '/usr/X11R6/.zk', '/usr/X11R6/.zk/xfs', '/usr/X11R6/.zk/echo', '/etc/sysconfig/console/load.zk');", 
-      "interval": "3600", 
-      "description": "zk_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "ramen_worm": {
-      "query": "select * from file where path in ('/usr/lib/ldlibps.so', '/usr/lib/ldlibns.so', '/usr/lib/ldliblogin.so', '/usr/src/.poop', '/tmp/ramen.tgz', '/etc/xinetd.d/asp');", 
-      "interval": "3600", 
-      "description": "ramen_worm", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "maniac_rk": {
-      "query": "select * from file where path in ('/usr/bin/mailrc');", 
-      "interval": "3600", 
-      "description": "maniac_rk", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "bmbl_rootkit": {
-      "query": "select * from file where path in ('/etc/.bmbl', '/etc/.bmbl/sk');", 
-      "interval": "3600", 
-      "description": "bmbl_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "suckit_rootkit": {
-      "query": "select * from file where path in ('/lib/.x', '/lib/sk');", 
-      "interval": "3600", 
-      "description": "suckit_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "adore_rootkit": {
-      "query": "select * from file where path in ('/etc/bin/ava', '/etc/sbin/ava');", 
-      "interval": "3600", 
-      "description": "adore_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "ldp_worm": {
-      "query": "select * from file where path in ('/dev/.kork', '/bin/.login', '/bin/.ps');", 
-      "interval": "3600", 
-      "description": "ldp_worm", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "romanian_rootkit": {
-      "query": "select * from file where path in ('/usr/sbin/initdl', '/usr/sbin/xntps');", 
-      "interval": "3600", 
-      "description": "romanian_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "illogic_rootkit": {
-      "query": "select * from file where path in ('/lib/security/.config', '/usr/bin/sia', '/etc/ld.so.hash');", 
-      "interval": "3600", 
-      "description": "illogic_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "bobkit_rootkit": {
-      "query": "select * from file where path in ('/usr/include/.../', '/usr/lib/.../', '/usr/sbin/.../', '/usr/bin/ntpsx', '/tmp/.bkp', '/usr/lib/.bkit-');", 
-      "interval": "3600", 
-      "description": "bobkit_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "monkit": {
-      "query": "select * from file where path in ('/lib/defs');", 
-      "interval": "3600", 
-      "description": "monkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "override_rootkit": {
-      "query": "select * from file where path in ('/dev/grid-hide-pid-', '/dev/grid-unhide-pid-', '/dev/grid-show-pids', '/dev/grid-hide-port-', '/dev/grid-unhide-port-');", 
-      "interval": "3600", 
-      "description": "override_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "madalin_rootkit": {
-      "query": "select * from file where path in ('/usr/include/icekey.h', '/usr/include/iceconf.h', '/usr/include/iceseed.h');", 
-      "interval": "3600", 
-      "description": "madalin_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "solaris_worm": {
-      "query": "select * from file where path in ('/var/adm/.profile', '/var/spool/lp/.profile', '/var/adm/sa/.adm', '/var/spool/lp/admins/.lp');", 
-      "interval": "3600", 
-      "description": "solaris_worm", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "phalanx_rootkit": {
-      "query": "select * from file where path in ('/usr/share/.home*', '/usr/share/.home*/tty', '/etc/host.ph1', '/bin/host.ph1');", 
-      "interval": "3600", 
-      "description": "phalanx_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "ark_rootkit": {
-      "query": "select * from file where path in ('/dev/ptyxx');", 
-      "interval": "3600", 
-      "description": "ark_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "tribe_bot": {
-      "query": "select * from file where path in ('/dev/wd4');", 
-      "interval": "3600", 
-      "description": "tribe_bot", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "cback_worm": {
-      "query": "select * from file where path in ('/tmp/cback', '/tmp/derfiq');", 
-      "interval": "3600", 
-      "description": "cback_worm", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "optickit": {
-      "query": "select * from file where path in ('/usr/bin/xchk', '/usr/bin/xsf', '/usr/bin/xsf', '/usr/bin/xchk');", 
-      "interval": "3600", 
-      "description": "optickit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "anonoiyng_rootkit": {
-      "query": "select * from file where path in ('/usr/sbin/mech', '/usr/sbin/kswapd');", 
-      "interval": "3600", 
-      "description": "anonoiyng_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "loc_rookit": {
-      "query": "select * from file where path in ('/tmp/xp', '/tmp/kidd0.c', '/tmp/kidd0');", 
-      "interval": "3600", 
-      "description": "loc_rookit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "showtee": {
-      "query": "select * from file where path in ('/usr/lib/.egcs', '/usr/lib/.wormie', '/usr/lib/.kinetic', '/usr/lib/liblog.o', '/usr/include/cron.h', '/usr/include/chk.h');", 
-      "interval": "3600", 
-      "description": "showtee", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "zarwt_rootkit": {
-      "query": "select * from file where path in ('/bin/imin', '/bin/imout');", 
-      "interval": "3600", 
-      "description": "zarwt_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "lion_worm": {
-      "query": "select * from file where path in ('/dev/.lib', '/dev/.lib/1iOn.sh', '/bin/mjy', '/bin/in.telnetd', '/usr/info/torn');", 
-      "interval": "3600", 
-      "description": "lion_worm", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "suspicious_file": {
-      "query": "select * from file where path in ('/etc/rc.d/init.d/rc.modules', '/lib/ldd.so', '/usr/man/muie', '/usr/X11R6/include/pain', '/usr/bin/sourcemask', '/usr/bin/ras2xm', '/usr/bin/ddc', '/usr/bin/jdc', '/usr/sbin/in.telnet', '/sbin/vobiscum', '/usr/sbin/jcd', '/usr/sbin/atd2', '/usr/bin/ishit', '/usr/bin/.etc', '/usr/bin/xstat', '/var/run/.tmp', '/usr/man/man1/lib/.lib', '/usr/man/man2/.man8', '/var/run/.pid', '/lib/.so', '/lib/.fx', '/lib/lblip.tk', '/usr/lib/.fx', '/var/local/.lpd', '/dev/rd/cdb', '/dev/.rd/', '/usr/lib/pt07', '/usr/bin/atm', '/tmp/.cheese', '/dev/.arctic', '/dev/.xman', '/dev/.golf', '/dev/srd0', '/dev/ptyzx', '/dev/ptyzg', '/dev/xdf1', '/dev/ttyop', '/dev/ttyof', '/dev/hd7', '/dev/hdx1', '/dev/hdx2', '/dev/xdf2', '/dev/ptyp', '/dev/ptyr', '/sbin/pback', '/usr/man/man3/psid', '/proc/kset', '/usr/bin/gib', '/usr/bin/snick', '/usr/bin/kfl', '/tmp/.dump', '/var/.x', '/var/.x/psotnic');", 
-      "interval": "3600", 
-      "description": "suspicious_file", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "apa_kit": {
-      "query": "select * from file where path in ('/usr/share/.aPa');", 
-      "interval": "3600", 
-      "description": "apa_kit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "enye_sec_rootkit": {
-      "query": "select * from file where path in ('/etc/.enyelkmHIDE^IT.ko');", 
-      "interval": "3600", 
-      "description": "enye_sec_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "rk17": {
-      "query": "select * from file where path in ('/bin/rtty', '/bin/squit', '/sbin/pback', '/proc/kset', '/usr/src/linux/modules/autod.o', '/usr/src/linux/modules/soundx.o');", 
-      "interval": "3600", 
-      "description": "rk17", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "trk_rootkit": {
-      "query": "select * from file where path in ('/usr/bin/soucemask', '/usr/bin/sourcemask');", 
-      "interval": "3600", 
-      "description": "trk_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "scalper_installed": {
-      "query": "select * from file where path in ('/tmp/.uua', '/tmp/.a');", 
-      "interval": "3600", 
-      "description": "scalper_installed", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "hidr00tkit": {
-      "query": "select * from file where path in ('/var/lib/games/.k');", 
-      "interval": "3600", 
-      "description": "hidr00tkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "beastkit_rootkit": {
-      "query": "select * from file where path in ('/usr/local/bin/bin', '/usr/man/.man10', '/usr/sbin/arobia', '/usr/lib/elm/arobia', '/usr/local/bin/.../bktd');", 
-      "interval": "3600", 
-      "description": "beastkit_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "shv5_rootkit": {
-      "query": "select * from file where path in ('/lib/libsh.so', '/usr/lib/libsh');", 
-      "interval": "3600", 
-      "description": "shv5_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "esrk_rootkit": {
-      "query": "select * from file where path in ('/usr/lib/tcl5.3');", 
-      "interval": "3600", 
-      "description": "esrk_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "shkit_rootkit": {
-      "query": "select * from file where path in ('/lib/security/.config', '/etc/ld.so.hash');", 
-      "interval": "3600", 
-      "description": "shkit_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "knark_installed": {
-      "query": "select * from file where path in ('/proc/knark', '/dev/.pizda', '/dev/.pula', '/dev/.pula');", 
-      "interval": "3600", 
-      "description": "knark_installed", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "volc_rootkit": {
-      "query": "select * from file where path in ('/usr/lib/volc', '/usr/bin/volc');", 
-      "interval": "3600", 
-      "description": "volc_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "fu_rootkit": {
-      "query": "select * from file where path in ('/sbin/xc', '/usr/include/ivtype.h', '/bin/.lib');", 
-      "interval": "3600", 
-      "description": "fu_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "ajakit_rootkit": {
-      "query": "select * from file where path in ('/lib/.ligh.gh', '/lib/.libgh.gh', '/lib/.libgh-gh', '/dev/tux', '/dev/tux/.proc', '/dev/tux/.file');", 
-      "interval": "3600", 
-      "description": "ajakit_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "monkit_found": {
-      "query": "select * from file where path in ('/usr/lib/libpikapp.a');", 
-      "interval": "3600", 
-      "description": "monkit_found", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "t0rn_rootkit": {
-      "query": "select * from file where path in ('/usr/src/.puta', '/usr/info/.t0rn', '/lib/ldlib.tk', '/etc/ttyhash', '/sbin/xlogin');", 
-      "interval": "3600", 
-      "description": "t0rn_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
-    "adore_worm": {
-      "query": "select * from file where path in ('/dev/.shit/red.tgz', '/usr/lib/libt', '/usr/bin/adore');", 
-      "interval": "3600", 
-      "description": "adore_worm", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
     "55808.a_worm": {
-      "query": "select * from file where path in ('/tmp/.../a', '/tmp/.../r');", 
-      "interval": "3600", 
-      "description": "55808.a_worm", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
-    }, 
+      "description": "55808.a_worm",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/tmp/.../a', '/tmp/.../r');",
+      "value": "Artifacts used by this malware"
+    },
+    "adore_rootkit": {
+      "description": "adore_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/etc/bin/ava', '/etc/sbin/ava');",
+      "value": "Artifacts used by this malware"
+    },
+    "adore_worm": {
+      "description": "adore_worm",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/dev/.shit/red.tgz', '/usr/lib/libt', '/usr/bin/adore');",
+      "value": "Artifacts used by this malware"
+    },
+    "ajakit_rootkit": {
+      "description": "ajakit_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/lib/.ligh.gh', '/lib/.libgh.gh', '/lib/.libgh-gh', '/dev/tux', '/dev/tux/.proc', '/dev/tux/.file');",
+      "value": "Artifacts used by this malware"
+    },
+    "anonoiyng_rootkit": {
+      "description": "anonoiyng_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/sbin/mech', '/usr/sbin/kswapd');",
+      "value": "Artifacts used by this malware"
+    },
+    "apa_kit": {
+      "description": "apa_kit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/share/.aPa');",
+      "value": "Artifacts used by this malware"
+    },
+    "ark_rootkit": {
+      "description": "ark_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/dev/ptyxx');",
+      "value": "Artifacts used by this malware"
+    },
+    "bash_door": {
+      "description": "bash_door",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/tmp/mcliZokhb', '/tmp/mclzaKmfa');",
+      "value": "Artifacts used by this malware"
+    },
+    "beastkit_rootkit": {
+      "description": "beastkit_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/local/bin/bin', '/usr/man/.man10', '/usr/sbin/arobia', '/usr/lib/elm/arobia', '/usr/local/bin/.../bktd');",
+      "value": "Artifacts used by this malware"
+    },
+    "bmbl_rootkit": {
+      "description": "bmbl_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/etc/.bmbl', '/etc/.bmbl/sk');",
+      "value": "Artifacts used by this malware"
+    },
+    "bobkit_rootkit": {
+      "description": "bobkit_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/include/.../', '/usr/lib/.../', '/usr/sbin/.../', '/usr/bin/ntpsx', '/tmp/.bkp', '/usr/lib/.bkit-');",
+      "value": "Artifacts used by this malware"
+    },
+    "cback_worm": {
+      "description": "cback_worm",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/tmp/cback', '/tmp/derfiq');",
+      "value": "Artifacts used by this malware"
+    },
+    "enye_sec_rootkit": {
+      "description": "enye_sec_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/etc/.enyelkmHIDE^IT.ko');",
+      "value": "Artifacts used by this malware"
+    },
+    "esrk_rootkit": {
+      "description": "esrk_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/lib/tcl5.3');",
+      "value": "Artifacts used by this malware"
+    },
+    "fu_rootkit": {
+      "description": "fu_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/sbin/xc', '/usr/include/ivtype.h', '/bin/.lib');",
+      "value": "Artifacts used by this malware"
+    },
+    "hidr00tkit": {
+      "description": "hidr00tkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/var/lib/games/.k');",
+      "value": "Artifacts used by this malware"
+    },
+    "illogic_rootkit": {
+      "description": "illogic_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/lib/security/.config', '/usr/bin/sia', '/etc/ld.so.hash');",
+      "value": "Artifacts used by this malware"
+    },
+    "kenga3_rootkit": {
+      "description": "kenga3_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/include/. .');",
+      "value": "Artifacts used by this malware"
+    },
+    "knark_installed": {
+      "description": "knark_installed",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/proc/knark', '/dev/.pizda', '/dev/.pula', '/dev/.pula');",
+      "value": "Artifacts used by this malware"
+    },
+    "ldp_worm": {
+      "description": "ldp_worm",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/dev/.kork', '/bin/.login', '/bin/.ps');",
+      "value": "Artifacts used by this malware"
+    },
+    "lion_worm": {
+      "description": "lion_worm",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/dev/.lib', '/dev/.lib/1iOn.sh', '/bin/mjy', '/bin/in.telnetd', '/usr/info/torn');",
+      "value": "Artifacts used by this malware"
+    },
+    "loc_rookit": {
+      "description": "loc_rookit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/tmp/xp', '/tmp/kidd0.c', '/tmp/kidd0');",
+      "value": "Artifacts used by this malware"
+    },
+    "lrk_rootkit": {
+      "description": "lrk_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/dev/ida/.inet');",
+      "value": "Artifacts used by this malware"
+    },
+    "madalin_rootkit": {
+      "description": "madalin_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/include/icekey.h', '/usr/include/iceconf.h', '/usr/include/iceseed.h');",
+      "value": "Artifacts used by this malware"
+    },
+    "maniac_rk": {
+      "description": "maniac_rk",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/bin/mailrc');",
+      "value": "Artifacts used by this malware"
+    },
+    "mithra`s_rootkit": {
+      "description": "mithra`s_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/lib/locale/uboot');",
+      "value": "Artifacts used by this malware"
+    },
+    "monkit": {
+      "description": "monkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/lib/defs');",
+      "value": "Artifacts used by this malware"
+    },
+    "monkit_found": {
+      "description": "monkit_found",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/lib/libpikapp.a');",
+      "value": "Artifacts used by this malware"
+    },
+    "old_rootkits": {
+      "description": "old_rootkits",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/include/rpc/ ../kit', '/usr/include/rpc/ ../kit2', '/usr/doc/.sl', '/usr/doc/.sp', '/usr/doc/.statnet', '/usr/doc/.logdsys', '/usr/doc/.dpct', '/usr/doc/.gifnocfi', '/usr/doc/.dnif', '/usr/doc/.nigol');",
+      "value": "Artifacts used by this malware"
+    },
+    "omega_worm": {
+      "description": "omega_worm",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/dev/chr');",
+      "value": "Artifacts used by this malware"
+    },
+    "optickit": {
+      "description": "optickit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/bin/xchk', '/usr/bin/xsf', '/usr/bin/xsf', '/usr/bin/xchk');",
+      "value": "Artifacts used by this malware"
+    },
+    "override_rootkit": {
+      "description": "override_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/dev/grid-hide-pid-', '/dev/grid-unhide-pid-', '/dev/grid-show-pids', '/dev/grid-hide-port-', '/dev/grid-unhide-port-');",
+      "value": "Artifacts used by this malware"
+    },
+    "phalanx_rootkit": {
+      "description": "phalanx_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/share/.home*', '/usr/share/.home*/tty', '/etc/host.ph1', '/bin/host.ph1');",
+      "value": "Artifacts used by this malware"
+    },
+    "ramen_worm": {
+      "description": "ramen_worm",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/lib/ldlibps.so', '/usr/lib/ldlibns.so', '/usr/lib/ldliblogin.so', '/usr/src/.poop', '/tmp/ramen.tgz', '/etc/xinetd.d/asp');",
+      "value": "Artifacts used by this malware"
+    },
+    "rh_sharpe": {
+      "description": "rh_sharpe",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/bin/.ps', '/usr/bin/cleaner', '/usr/bin/slice', '/usr/bin/vadim', '/usr/bin/.ps', '/bin/.lpstree', '/usr/bin/.lpstree', '/usr/bin/lnetstat', '/bin/lnetstat', '/usr/bin/ldu', '/bin/ldu', '/usr/bin/lkillall', '/bin/lkillall', '/usr/include/rpcsvc/du');",
+      "value": "Artifacts used by this malware"
+    },
+    "rk17": {
+      "description": "rk17",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/bin/rtty', '/bin/squit', '/sbin/pback', '/proc/kset', '/usr/src/linux/modules/autod.o', '/usr/src/linux/modules/soundx.o');",
+      "value": "Artifacts used by this malware"
+    },
+    "romanian_rootkit": {
+      "description": "romanian_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/sbin/initdl', '/usr/sbin/xntps');",
+      "value": "Artifacts used by this malware"
+    },
+    "rsha": {
+      "description": "rsha",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/bin/kr4p', '/usr/bin/n3tstat', '/usr/bin/chsh2', '/usr/bin/slice2', '/etc/rc.d/rsha');",
+      "value": "Artifacts used by this malware"
+    },
+    "sadmind/iis_worm": {
+      "description": "sadmind/iis_worm",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/dev/cuc');",
+      "value": "Artifacts used by this malware"
+    },
+    "scalper_installed": {
+      "description": "scalper_installed",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/tmp/.uua', '/tmp/.a');",
+      "value": "Artifacts used by this malware"
+    },
+    "shitc": {
+      "description": "shitc",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/bin/home', '/sbin/home', '/usr/sbin/in.slogind');",
+      "value": "Artifacts used by this malware"
+    },
+    "shkit_rootkit": {
+      "description": "shkit_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/lib/security/.config', '/etc/ld.so.hash');",
+      "value": "Artifacts used by this malware"
+    },
+    "showtee": {
+      "description": "showtee",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/lib/.egcs', '/usr/lib/.wormie', '/usr/lib/.kinetic', '/usr/lib/liblog.o', '/usr/include/cron.h', '/usr/include/chk.h');",
+      "value": "Artifacts used by this malware"
+    },
+    "showtee_/_romanian_rootkit": {
+      "description": "showtee_/_romanian_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/include/addr.h', '/usr/include/file.h', '/usr/include/syslogs.h', '/usr/include/proc.h');",
+      "value": "Artifacts used by this malware"
+    },
+    "shv5_rootkit": {
+      "description": "shv5_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/lib/libsh.so', '/usr/lib/libsh');",
+      "value": "Artifacts used by this malware"
+    },
+    "slapper_installed": {
+      "description": "slapper_installed",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/tmp/.bugtraq', '/tmp/.bugtraq.c', '/tmp/.cinik', '/tmp/.b', '/tmp/httpd', '/tmp./update', '/tmp/.unlock', '/tmp/.font-unix/.cinik', '/tmp/.cinik');",
+      "value": "Artifacts used by this malware"
+    },
+    "solaris_worm": {
+      "description": "solaris_worm",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/var/adm/.profile', '/var/spool/lp/.profile', '/var/adm/sa/.adm', '/var/spool/lp/admins/.lp');",
+      "value": "Artifacts used by this malware"
+    },
+    "suckit_rootkit": {
+      "description": "suckit_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/lib/.x', '/lib/sk');",
+      "value": "Artifacts used by this malware"
+    },
+    "suspicious_file": {
+      "description": "suspicious_file",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/etc/rc.d/init.d/rc.modules', '/lib/ldd.so', '/usr/man/muie', '/usr/X11R6/include/pain', '/usr/bin/sourcemask', '/usr/bin/ras2xm', '/usr/bin/ddc', '/usr/bin/jdc', '/usr/sbin/in.telnet', '/sbin/vobiscum', '/usr/sbin/jcd', '/usr/sbin/atd2', '/usr/bin/ishit', '/usr/bin/.etc', '/usr/bin/xstat', '/var/run/.tmp', '/usr/man/man1/lib/.lib', '/usr/man/man2/.man8', '/var/run/.pid', '/lib/.so', '/lib/.fx', '/lib/lblip.tk', '/usr/lib/.fx', '/var/local/.lpd', '/dev/rd/cdb', '/dev/.rd/', '/usr/lib/pt07', '/usr/bin/atm', '/tmp/.cheese', '/dev/.arctic', '/dev/.xman', '/dev/.golf', '/dev/srd0', '/dev/ptyzx', '/dev/ptyzg', '/dev/xdf1', '/dev/ttyop', '/dev/ttyof', '/dev/hd7', '/dev/hdx1', '/dev/hdx2', '/dev/xdf2', '/dev/ptyp', '/dev/ptyr', '/sbin/pback', '/usr/man/man3/psid', '/proc/kset', '/usr/bin/gib', '/usr/bin/snick', '/usr/bin/kfl', '/tmp/.dump', '/var/.x', '/var/.x/psotnic');",
+      "value": "Artifacts used by this malware"
+    },
+    "t0rn_rootkit": {
+      "description": "t0rn_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/src/.puta', '/usr/info/.t0rn', '/lib/ldlib.tk', '/etc/ttyhash', '/sbin/xlogin');",
+      "value": "Artifacts used by this malware"
+    },
+    "tc2_worm": {
+      "description": "tc2_worm",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/info/.tc2k', '/usr/bin/util', '/usr/sbin/initcheck', '/usr/sbin/ldb');",
+      "value": "Artifacts used by this malware"
+    },
+    "telekit_trojan": {
+      "description": "telekit_trojan",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/dev/hda06', '/usr/info/libc1.so');",
+      "value": "Artifacts used by this malware"
+    },
+    "tribe_bot": {
+      "description": "tribe_bot",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/dev/wd4');",
+      "value": "Artifacts used by this malware"
+    },
+    "trk_rootkit": {
+      "description": "trk_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/bin/soucemask', '/usr/bin/sourcemask');",
+      "value": "Artifacts used by this malware"
+    },
     "tuxkit_rootkit": {
-      "query": "select * from file where path in ('/dev/tux', '/usr/bin/xsf', '/usr/bin/xchk');", 
-      "interval": "3600", 
-      "description": "tuxkit_rootkit", 
-      "value": "Artifacts used by this malware", 
-      "platform": "linux"
+      "description": "tuxkit_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/dev/tux', '/usr/bin/xsf', '/usr/bin/xchk');",
+      "value": "Artifacts used by this malware"
+    },
+    "volc_rootkit": {
+      "description": "volc_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/lib/volc', '/usr/bin/volc');",
+      "value": "Artifacts used by this malware"
+    },
+    "zarwt_rootkit": {
+      "description": "zarwt_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/bin/imin', '/bin/imout');",
+      "value": "Artifacts used by this malware"
+    },
+    "zk_rootkit": {
+      "description": "zk_rootkit",
+      "interval": "3600",
+      "platform": "linux",
+      "query": "select * from file where path in ('/usr/share/.zk', '/usr/share/.zk/zk', '/etc/1ssue.net', '/usr/X11R6/.zk', '/usr/X11R6/.zk/xfs', '/usr/X11R6/.zk/echo', '/etc/sysconfig/console/load.zk');",
+      "value": "Artifacts used by this malware"
     }
-  }
+  },
+  "version": "1.4.5"
 }

--- a/output/packs/osx-attacks.conf
+++ b/output/packs/osx-attacks.conf
@@ -1,0 +1,618 @@
+{
+  "platform": "darwin",
+  "queries": {
+    "WireLurker": {
+      "query" : "select * from launchd where \
+        name = 'com.apple.machook_damon.plist' OR \
+        name = 'com.apple.globalupdate.plist' OR \
+        name = 'com.apple.appstore.plughelper.plist' OR \
+        name = 'com.apple.MailServiceAgentHelper.plist' OR \
+        name = 'com.apple.systemkeychain-helper.plist' OR \
+        name = 'com.apple.periodic-dd-mm-yy.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://github.com/PaloAltoNetworks-BD/WireLurkerDetector)",
+      "value" : "Artifact used by this malware"
+    },
+    "Leverage-A_1": {
+      "query" : "select * from launchd where path like '%UserEvent.System.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.intego.com/mac-security-blog/new-mac-trojan-discovered-related-to-syria/)",
+      "value" : "Artifact used by this malware"
+    },
+    "Leverage-A_2": {
+      "query" : "select * from file where path = '/Users/Shared/UserEvent.app';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.intego.com/mac-security-blog/new-mac-trojan-discovered-related-to-syria/)",
+      "value" : "Artifact used by this malware"
+    },
+    "Leverage-A_3": {
+      "query" : "select * from launchd where name = 'com.GetFlashPlayer.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://www.volexity.com/blog/2017/07/24/real-news-fake-flash-mac-os-x-users-targeted/)",
+      "value" : "Artifact used by this malware"
+    },
+    "Tibet.D": {
+      "query" : "select * from launchd where path like '%com.apple.AudioService.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.intego.com/mac-security-blog/os-x-malware-tibet-variant-found/)",
+      "value" : "Artifact used by this malware"
+    },
+    "DevilRobber": {
+      "query" : "select * from launchd where name = 'com.apple.legion.plist' or name = 'com.apple.pixel.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://www.f-secure.com/v-descs/backdoor_osx_devilrobber_a.shtml)",
+      "value" : "Artifact used by this malware"
+    },
+    "XSLCmd": {
+      "query" : "select * from launchd where name = 'com.apple.service.clipboardd.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://www.fireeye.com/blog/threat-research/2014/09/forced-to-adapt-xslcmd-backdoor-now-on-os-x.html)",
+      "value" : "Artifact used by this malware"
+    },
+    "Olyx": {
+      "query" : "select * from launchd where name = 'com.apple.DockActions.plist' or name like '%www. google.com.tstart.plist%';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://www.f-secure.com/v-descs/backdoor_osx_olyx_c.shtml)",
+      "value" : "Artifact used by this malware"
+    },
+    "Imuler": {
+      "query" : "select * from launchd where name = 'checkflr.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://www.f-secure.com/v-descs/backdoor_osx_imuler_a.shtml)",
+      "value" : "Artifact used by this malware"
+    },
+    "iWorkServ": {
+      "query" : "select * from startup_items where path like '%iWorkServices%';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://www.f-secure.com/v-descs/backdoor_osx_iworkserv_a.shtml)",
+      "value" : "Artifact used by this malware"
+    },
+    "Morcut": {
+      "query" : "select * from launchd where name = 'com.apple.mdworker.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.trendmicro.com/vinfo/us/threat-encyclopedia/malware/osx_morcut.a)",
+      "value" : "Artifact used by this malware"
+    },
+    "BlazingKeylogger": {
+      "query" : "select * from launchd where name = 'com.BT.BPK.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.blazingtools.com/mac_keylogger.html)",
+      "value" : "Artifact used by this malware"
+    },
+    "Icefog": {
+      "query" : "select * from launchd where name = 'apple.launchd.plist' or name = 'com.apple.launchport.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://securelist.com/blog/research/57331/the-icefog-apt-a-tale-of-cloak-and-three-daggers/)",
+      "value" : "Artifact used by this malware"
+    },
+    "Careto": {
+      "query" : "select * from launchd where path like '%com.apple.launchport.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://blog.kaspersky.com/the-mask-unveiling-the-worlds-most-sophisticated-apt-campaign/)",
+      "value" : "Artifact used by this malware"
+    },
+    "Inqtana": {
+      "query" : "select * from launchd where name = 'com.pwned.plist' or name = 'com.openbundle.plist' or name = 'com.adobe.reader.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://www.f-secure.com/v-descs/inqtana_a.shtml)",
+      "value" : "Artifact used by this malware"
+    },
+    "MacKontrol": {
+      "query" : "select * from launchd where name = 'com.apple.FolderActionsxl.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://www.f-secure.com/v-descs/backdoor_osx_mackontrol_a.shtml)",
+      "value" : "Artifact used by this malware"
+    },
+    "PubSab": {
+      "query" : "select * from launchd where name = 'com.apple.PubSabAgent.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://www.f-secure.com/v-descs/backdoor_osx_sabpab_a.shtml)",
+      "value" : "Artifact used by this malware"
+    },
+    "Dockster": {
+      "query" : "select * from launchd where name = 'mac.Dockset.deman.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.trendmicro.com/vinfo/us/threat-encyclopedia/malware/osx_dockster.a)",
+      "value" : "Artifact used by this malware"
+    },
+    "CallMe": {
+      "query" : "select * from launchd where name = 'realPlayerUpdate.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://www.f-secure.com/weblog/archives/00002546.html)",
+      "value" : "Artifact used by this malware"
+    },
+    "Whitesmoke": {
+      "query" : "select * from launchd where name = 'com.whitesmoke.uploader.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.thesafemac.com/osxfkcodec-a-in-action/ )",
+      "value" : "Artifact used by this malware"
+    },
+    "Codecm": {
+      "query" : "select * from launchd where name = 'com.codecm.uploader.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.thesafemac.com/osxfkcodec-a-in-action/)",
+      "value" : "Artifact used by this malware"
+    },
+    "iWorm": {
+      "query" : "select * from launchd where name = 'com.JavaW.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://www.virusbtn.com/virusbulletin/archive/2014/10/vb201410-iWorm)",
+      "value" : "Artifact used by this malware"
+    },
+    "iWorm_1": {
+      "query" : "select * from file where path like '/Library/Application Support/JavaW%';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(https://www.virusbtn.com/virusbulletin/archive/2014/10/vb201410-iWorm)",
+      "value" : "Artifact used by this malware"
+    },
+    "SniperSpy": {
+      "query" : "select * from launchd where name = 'com.rxs.syslogagent.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.symantec.com/security_response/writeup.jsp?docid=2010-081606-4034-99&tabid=2)",
+      "value" : "Artifact used by this malware"
+    },
+    "Vsearch": {
+      "query" : "select * from launchd where \
+        name = 'com.vsearch.agent.plist' OR \
+        name = 'com.vsearch.daemon.plist' OR \
+        name = 'com.vsearch.helper.plist' OR \
+        name = 'Jack.plist' OR \
+        program_arguments = '/etc/run_upd.sh' OR \
+        program_arguments LIKE '/Library/Application Support/%/Agent/agent.app/Contents/MacOS/agent%';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.thesafemac.com/arg-downlite/)",
+      "value" : "Artifact used by this malware"
+    },
+    "Buca": {
+      "query" : "select * from launchd where name = 'com.webhelper.plist' or name = 'com.webtools.update.agent.plist' or name = 'com.webtools.uninstaller.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.thesafemac.com/arg-buca-apps/)",
+      "value" : "Artifact used by this malware"
+    },
+    "Conduit": {
+      "query" : "select * from launchd where path like '%com.conduit.loader.agent.plist' or name = 'com.conduit.loader.agent.plist' or path like '%com.perion.searchprotectd.plist' or name = 'com.perion.searchprotectd.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.thesafemac.com/arg-conduit/)",
+      "value" : "Artifact used by this malware"
+    },
+    "Genieo": {
+      "query" : "select * from launchd where \
+        name = 'com.genieo.completer.download.plist' OR \
+        name = 'com.genieo.completer.update.plist' OR \
+        name = 'com.genieo.completer.ltvbit.plist' OR \
+        name = 'com.installer.completer.download.plist' OR \
+        name = 'com.installer.completer.update.plist' OR \
+        name = 'com.installer.completer.ltvbit.plist' OR \
+        name = 'com.genieoinnovation.macextension.plist' OR \
+        name = 'com.genieoinnovation.macextension.client.plist' OR \
+        name = 'com.genieo.engine.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "(http://www.thesafemac.com/arg-genieo/)",
+      "value" : "Artifact used by this malware"
+    },
+    "GenieoPart2": {
+      "query" : "select * from launchd where program_arguments like '/Users/%/Library/Application Support/%/%.app/Contents/MacOS/App% -trigger download -isDev % -installVersion % -firstAppId % -identity %';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "New version of Genieo",
+      "value" : "Artifact used by this malware"
+    },
+    "HackingTeam_Mac_RAT1": {
+      "query" : "select * from file where path = '/dev/ptmx0';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "Detect RAT used by Hacking Team",
+      "value" : "Artifact used by this malware"
+    },
+    "HackingTeam_Mac_RAT2": {
+      "query" : "select * from apps where bundle_identifier = 'com.ht.RCSMac';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "Detect RAT used by Hacking Team",
+      "value" : "Artifact used by this malware"
+    },
+    "HackingTeam_Mac_RAT3": {
+      "query" : "select * from launchd where \
+        label = 'com.ht.RCSMac' OR \
+        name = 'com.apple.loginStoreagent.plist' OR \
+        name = 'com.apple.mdworker.plist' OR \
+        name = 'com.apple.UIServerLogin.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "Detect RAT used by Hacking Team",
+      "value" : "Artifact used by this malware"
+    },
+    "HackingTeam_Mac_Persistence": {
+      "query": "select * from file where directory like '/Users/%/Library/Preferences/8pHbqThW%';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "Detection persistency by Hacking Team",
+      "value": "Artifact used by Hacking Team"
+    },
+    "xprotect_reports": {
+      "query": "select * from xprotect_reports;",
+      "interval": 1200,
+      "removed": false,
+      "version": "1.4.5",
+      "description": "Report on Apple/OS X XProtect 'report' generation. Reports are generated when OS X matches an item in xprotect_entries.",
+      "value": "Although XProtect reports are rare, they may be worth collecting and aggregating internally."
+    },
+    "Keranger_1": {
+      "query": "select * from processes where name = 'kernel_service';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/",
+      "value": "Artifact used by this malware"
+    },
+    "Keranger_2": {
+      "query": "select * from file where \
+        path LIKE '/Users/%/Library/.kernel_%' OR \
+        path LIKE '/Users/%/Library/kernel_service';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/",
+      "value": "Artifact used by this malware"
+    },
+    "PremierOpinion": {
+      "query": "select * from launchd where name = 'PremierOpinion.plist' or name = 'PremierOpinionAgent.plist';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "(http://www.thesafemac.com/arg-premier-opinion/)",
+      "value": "Artifact used by this malware"
+    },
+    "Bundlore": {
+      "query": "select * from launchd where name like 'com.WebShoppy.%.plist' or name like 'com.SoftwareUpdater.%.plist' or name like 'cinema-plus%.plist' or name like 'com.WebTools.%.plist' or name like 'com.crossrider.%.plist' or name like 'shopy-mate_%.plist' or name like 'com.WebShopper.%.plist';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "(http://www.thesafemac.com/arg-bundlore/)",
+      "value": "Artifact used by this malware"
+    },
+    "Spigot": {
+      "query": "select * from launchd where name like 'com.spigot.%.plist';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "(http://www.thesafemac.com/arg-spigot/)",
+      "value": "Artifact used by this malware"
+    },
+    "SearchInstUpdater": {
+      "query": "select * from launchd where name like 'com.updater.mc%.plist' or name like 'com.updater.watch.mc%.plist';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "(https://www.virustotal.com/en/file/9530d481f7bb07aac98a46357bfcff96e2936a90571b4629ae865a2ce63e5c8e/analysis/)",
+      "value": "Artifact used by this malware"
+    },
+    "OSX_Pirrit": {
+      "query": "select * from plist where path = '/Library/Preferences/com.common.plist' and key = 'net_pref';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "(https://threatpost.com/mac-adware-osx-pirrit-unleashes-ad-overload-for-now/117273/)",
+      "value": "Artifact used by this malware"
+    },
+    "Backdoor_MAC_Eleanor": {
+      "query": "SELECT * FROM launchd WHERE name IN ('com.getdropbox.dropbox.integritycheck.plist','com.getdropbox.dropbox.timegrabber.plist','com.getdropbox.dropbox.usercontent.plist');",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "(https://blog.malwarebytes.com/cybercrime/2016/07/new-mac-backdoor-malware-eleanor/)",
+      "value": "Artifact used by this malware"
+    },
+    "EliteKeylogger": {
+      "query": "select * from launchd where name = 'com.apple.fonts.plist' and label = 'unknown';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "(https://www.elitekeyloggers.com/elite-keylogger-mac)",
+      "value": "Artifact used by this malware"
+    },
+    "Aobo_Keylogger": {
+      "query": "select * from launchd where name like 'com.ab.kl%.plist';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "(http://aobo.cc/aobo-mac-os-x-keylogger.html)",
+      "value": "Artifact used by this malware"
+    },
+    "OSX_Keydnap": {
+      "query": "select * from launchd where name IN ('com.apple.iCloud.sync.daemon', 'com.geticloud.icloud.photo');",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "(http://www.welivesecurity.com/2016/07/06/new-osxkeydnap-malware-hungry-credentials)",
+      "value": "Artifact used by this malware"
+    },
+    "Java_Adwind_Trojan": {
+      "query": "select * from launchd where name like 'org.%.plist' and program_arguments like '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java -Dapple.awt.UIElement=true -jar /Users/%/.%';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "(https://blog.malwarebytes.com/threat-analysis/2016/07/cross-platform-malware-adwind-infects-mac/)",
+      "value": "Artifact used by this malware"
+    },
+    "OSX_Backdoor_Mokes": {
+      "query": "select * from file where \
+        path LIKE '/Users/%/Library/App Store/storeuserd' OR \
+        path LIKE '/Users/%/Library/com.apple.spotlight/SpotlightHelper' OR \
+        path LIKE '/Users/%/Library/Dock/com.apple.dock.cache' OR \
+        path LIKE '/Users/%/Library/Dropbox/DropboxCache' OR \
+        path LIKE '/Users/%/Library/Skype/SkypeHelper' OR \
+        path LIKE '/Users/%/Library/Google/Chrome/nacld' OR \
+        path LIKE '/Users/%/Library/Firefox/Profiles/profiled';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "(https://securelist.com/blog/research/75990/the-missing-piece-sophisticated-os-x-backdoor-discovered/)",
+      "value": "Artifact used by this malware"
+    },
+    "OSX_Komplex": {
+      "query": "select * from file where path = '/Users/Shared/.local/kext' or path = '/Users/Shared/com.apple.updates.plist' or path = '/Users/Shared/start.sh';",
+      "interval": "3600",
+      "version": "1.4.5",
+      "description": "(http://researchcenter.paloaltonetworks.com/2016/09/unit42-sofacys-komplex-os-x-trojan/)",
+      "value": "Artifact used by this malware"
+    },
+    "OceanLotus_launchagent": {
+      "query" : "select * from launchd where name = 'com.google.plugins.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "OceanLotus Launch Agent (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
+      "value" : "Artifact used by this malware"
+    },
+    "OceanLotus_dropped_file_1": {
+      "query" : "select * from file, ( \
+        select '/Library/Logs/.Logs/corevideosd' ioc union \
+        select '/Library/.SystemPreferences/.prev/.ver.txt' ioc union \
+        select '/Library/Parallels/.cfg' ioc union \
+        select '/Library/Preferences/.fDTYuRs' ioc union \
+        select '/Library/Hash/.Hashtag/.hash' ioc union \
+        select '/Library/Hash/.hash' ioc \
+      ) iocs where \
+        file.path LIKE '/Users/%/' || ioc OR \
+        file.path = iocs.ioc OR \
+        file.path LIKE '/tmp/crunzip.temp.%';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
+      "value" : "Artifact used by this malware"
+    },
+    "XcodeGhost": {
+      "query" : "select * from ( \
+        select apps.bundle_short_version as xcode_version, \
+          apps.path as xcode_path, \
+          file.path, \
+          file.type as file_type \
+        from apps, file \
+        where apps.bundle_name='Xcode' and \
+          file.path like (apps.path || '/Contents/Developer/Platforms/%/Developer/SDKs/Library/%%') \
+      ) join hash using (path) where file_type = 'regular';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "Xcode Ghost dropped files (http://researchcenter.paloaltonetworks.com/2015/09/novel-malware-xcodeghost-modifies-xcode-infects-apple-ios-apps-and-hits-app-store/)",
+      "value" : "Artifact used by this malware"
+    },
+    "Quimitchin_Backdoor": {
+      "query" : "select * from launchd where name = 'com.client.client.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "Quimitchin Launch Agent (https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/)",
+      "value" : "Artifact used by this malware"
+    },
+    "Pronto": {
+      "query" : "select * from launchd where name = 'pronto.notification.plist' or name = 'pronto.update.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "ProntoApp Launch Agents (https://malwarefixes.com/remove-pronto-video-converter/)",
+      "value" : "Artifact used by this malware"
+    },
+    "OSX_DOK_1": {
+      "query" : "select * from launchd where name = 'com.apple.Safari.proxy.plist' or name = 'com.apple.Safari.proxy.pac';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "DOK Launch Agents (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
+      "value" : "Artifact used by this malware"
+    },
+    "OSX_DOK_2": {
+      "query" : "select common_name, sha1, subject_key_id from certificates where subject_key_id = 'e637d656f9f088ddca3b3b55c4fe698d8c97a552';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "DOK certificate (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
+      "value" : "Artifact used by this malware"
+    },
+    "OSX_DOK_3": {
+      "query" : "select * from file where path = '/Users/Shared/AppStore.app';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "DOK dropped file (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
+      "value" : "Artifact used by this malware"
+    },
+    "OSX_DOK_4": {
+      "query" : "select * from apps where bundle_name = 'Truesteer.AppStore';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "DOK malicious app (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
+      "value" : "Artifact used by this malware"
+    },
+    "OSX_Snake": {
+      "query" : "select * from file \
+         where path = '/Library/LaunchDaemons/com.adobe.update.plist' OR \
+           path = '/Library/Scripts/installd.sh' OR \
+           path = '/Library/Scripts/queue' OR \
+           path = '/tmp/.gdm-socket' OR \
+           path = '/tmp/.gdm-selinux' OR \
+           path LIKE '/var/tmp/.ur-%%';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "OS X port of Snake malware discovered by Fox-IT (https://blog.fox-it.com/2017/05/03/snake-coming-soon-in-mac-os-x-flavour/)",
+      "value" : "Artifacts created by this malware"
+    },
+    "OSX_Proton_Files": {
+      "query" : "select * from file \
+        where path like '/Users/%/Library/RenderFiles/activity_agent.app/' OR \
+        path like '/Users/%/Library/LaunchAgents/fr.handbrake.activity_agent.plist' OR \
+        path='/tmp/Updater.app' OR path='/Library/.rand/updateragent.app' OR \
+        path='/Library/LaunchAgents/com.apple.xpcd.plist' OR \
+        path='/Library/.cachedir' OR \
+        path='/Library/.random';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "OSX/Proton bundled with a tampered version of Handbrake and Elmedia Player: (https://objective-see.com/blog/blog_0x1D.html and https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
+      "value" : "Artifacts created by this malware"
+    },
+    "OSX_Proton_Launchd": {
+      "query" : "select * from launchd where name='com.Eltima.UpdaterAgent.plist' OR name='com.apple.xpcd.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "OSX/Proton bundled with a tampered version of Elmedia Player or Fake Symantec Blog: (https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/) and (https://blog.malwarebytes.com/threat-analysis/mac-threat-analysis/2017/11/osx-proton-spreading-through-fake-symantec-blog/)",
+      "value" : "Artifacts created by this malware"
+    },
+    "OSX_Proton_Process": {
+      "query" : "select * from processes \
+        where path like '/Users/%/Library/RenderFiles/activity_agent.app/Contents/MacOS/activity_agent' OR \
+        path='/Library/.rand/updateragent.app/Contents/MacOS/updateragent' OR \
+        path='/Library/.random/xpcd.app/Contents/MacOS/xpcd';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "OSX/Proton bundled with a tampered version of Handbrake and Elmedia Player: (https://objective-see.com/blog/blog_0x1D.html and https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
+      "value" : "Artifacts created by this malware"
+    },
+    "EmPyre_Agent": {
+      "query" : "select * from launchd where name = 'com.proxy.initialize.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "EmPyre post exploitation agent (https://github.com/EmpireProject/EmPyre/blob/master/lib/modules/persistence/osx/launchdaemonexecutable.py)",
+      "value" : "Artifacts created by this malware"
+    },
+    "OSX_FruitFly": {
+      "query" : "select * from launchd where name = 'com.client.client.plist';",
+      "interval" : "3600",
+      "version" : "1.4.5",
+      "description" : "FruitFly OSX Malware (https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/)",
+      "value" : "Artifacts created by this malware"
+    },
+    "OSX_Mughthesec": {
+      "query" : "select * from launchd where name = 'com.Mughthesec.plist';",
+      "interval" : "3600",
+      "version" : "1.4.5",
+      "description" : "Mughthesec OSX Malware (https://objective-see.com/blog/blog_0x20.html)",
+      "value" : "Artifacts created by this malware"
+    },
+    "OSX_HiddenLotus": {
+      "query" : "select * from launchd where name = 'com.apple.hidd.shared.plist';",
+      "interval" : "3600",
+      "version" : "1.4.5",
+      "description" : "Apple added XProtect rules for this sample: (https://www.virustotal.com/en/file/f261815905e77eebdb5c4ec06a7acdda7b68644b1f5155049f133be866d8b179/analysis/1509567775/)",
+      "value" : "Artifacts created by this malware"
+    },
+    "OSX_MaMi_DNS_Servers": {
+      "query" : "select * from dns_resolvers where type = 'nameserver' and address in ('82.163.143.135', '82.163.142.137');",
+      "interval" : "3600",
+      "version" : "2.8.0",
+      "description" : "MaMi OSX Malware 2017-01-12 (https://objective-see.com/blog/blog_0x26.html)",
+      "value" : "DNS Servers set by this malware"
+    },
+    "OSX_MaMi_Certificate": {
+      "query" : "select * from certificates where common_name like '%cloudguard.me%' and not_valid_after = '2352216315';",
+      "interval" : "3600",
+      "version" : "2.8.0",
+      "description" : "MaMi OSX Malware 2017-01-12 (https://objective-see.com/blog/blog_0x26.html)",
+      "value" : "bogus certificate added to key store by this malware"
+    },
+    "Behavioral_Reverse_Shell": {
+      "query" : "SELECT DISTINCT(processes.pid), processes.parent, processes.name, processes.path, \
+        processes.cmdline, processes.cwd, processes.root, processes.uid, processes.gid, \
+        processes.start_time, process_open_sockets.remote_address, process_open_sockets.remote_port, \
+        (SELECT cmdline FROM processes AS parent_cmdline WHERE pid=processes.parent) AS parent_cmdline \
+        FROM processes JOIN process_open_sockets USING (pid) \
+        LEFT OUTER JOIN process_open_files \
+        ON processes.pid = process_open_files.pid \
+        WHERE (name='sh' OR name='bash') \
+        AND process_open_files.pid IS NULL;",
+      "interval" : "3600",
+      "version" : "2.8.0",
+      "description" : "Find shell processes that have open sockets and no open files or TTY (https://clo.ng/blog/osquery_reverse_shell/)",
+      "value" : "Behavioral detection for potential reverse shells"
+    },
+    "OSX_ColdRoot_RAT_Launchd": {
+      "query" : "select * from launchd where name = 'com.apple.audio.driver.plist';",
+      "interval" : "3600",
+      "version" : "1.4.5",
+      "description" : "ColdRoot OSX Malware (https://objective-see.com/blog/blog_0x2A.html)",
+      "value" : "Artifacts created by this malware"
+    },
+    "OSX_ColdRoot_RAT_Files": {
+      "query" : "select * from file \
+        where path in ('/private/var/tmp/com.apple.audio.driver.app/', \
+        '/private/var/tmp/com.apple.audio.driver.app/Contents/MacOS/conx.wol');",
+      "interval" : "3600",
+      "version" : "1.4.5",
+      "description" : "ColdRoot OSX Malware (https://objective-see.com/blog/blog_0x2A.html)",
+      "value" : "Artifacts created by this malware"
+    },
+    "MacSearch_Adware": {
+      "query": "SELECT * FROM launchd WHERE path='/Library/LaunchAgents/tapufind.plist';",
+      "interval" : "3600",
+      "version" : "1.4.5",
+      "description" : "MacSearch OSX Adware (https://www.virustotal.com/latest-scan/15966224C4E25C9787A4A8C984A863E9)",
+      "value" : "Artifacts created by this adware"
+    },
+    "OSX_Dummy_Launchd": {
+      "query": "SELECT * FROM launchd WHERE name = 'com.startup.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html and https://isc.sans.edu/diary/23816)",
+      "value": "Artifacts created by this malware"
+    },
+    "OSX_Dummy_Files": {
+      "query" : "SELECT * FROM file \
+         WHERE path = '/Library/LaunchDaemons/com.startup.plist' OR \
+           path = '/var/root/script.sh' OR \
+           path = '/Users/Shared/dumpdummy' OR \
+           path = '/tmp/script.sh' OR \
+           path = '/tmp/com.startup.plist' OR \
+           path = '/tmp/dumpdummy';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html and https://isc.sans.edu/diary/23816)",
+      "value": "Artifacts created by this malware"
+    },
+    "Keyboard_Event_Taps": {
+      "query": "SELECT * FROM processes JOIN event_taps ON processes.pid = event_taps.tapping_process where event_taps.enabled = 1;",
+      "interval" : "3600",
+      "version": "3.3.0",
+      "description": "Finds processes that have active keyboard event taps, typically used by RATs and other malicious software for keylogging",
+      "value": "Process with keyboard event taps"
+    },
+    "OSX_SearchAwesome": {
+      "query" : "SELECT * FROM file \
+         WHERE path = '/Applications/spi.app' OR \
+           path = '/Users/%/Library/LaunchAgents/spid-uninstall.plist' OR \
+           path = '/Users/%/Library/LaunchAgents/spid.plist' OR \
+           path = '/Users/%/Library/SPI';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description": "OSX SearchAwesome Malware (https://blog.malwarebytes.com/threat-analysis/2018/10/mac-malware-intercepts-encrypted-web-traffic-for-ad-injection/)",
+      "value": "Artifacts created by this malware"
+    }
+  }
+}

--- a/output/packs/osx-attacks.conf
+++ b/output/packs/osx-attacks.conf
@@ -1,531 +1,531 @@
 {
   "platform": "darwin",
   "queries": {
-    "WireLurker": {
-      "query" : "select * from launchd where          name = 'com.apple.machook_damon.plist' OR          name = 'com.apple.globalupdate.plist' OR          name = 'com.apple.appstore.plughelper.plist' OR          name = 'com.apple.MailServiceAgentHelper.plist' OR          name = 'com.apple.systemkeychain-helper.plist' OR          name = 'com.apple.periodic-dd-mm-yy.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://github.com/PaloAltoNetworks-BD/WireLurkerDetector)",
-      "value" : "Artifact used by this malware"
-    },
-    "Leverage-A_1": {
-      "query" : "select * from launchd where path like '%UserEvent.System.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.intego.com/mac-security-blog/new-mac-trojan-discovered-related-to-syria/)",
-      "value" : "Artifact used by this malware"
-    },
-    "Leverage-A_2": {
-      "query" : "select * from file where path = '/Users/Shared/UserEvent.app';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.intego.com/mac-security-blog/new-mac-trojan-discovered-related-to-syria/)",
-      "value" : "Artifact used by this malware"
-    },
-    "Leverage-A_3": {
-      "query" : "select * from launchd where name = 'com.GetFlashPlayer.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://www.volexity.com/blog/2017/07/24/real-news-fake-flash-mac-os-x-users-targeted/)",
-      "value" : "Artifact used by this malware"
-    },
-    "Tibet.D": {
-      "query" : "select * from launchd where path like '%com.apple.AudioService.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.intego.com/mac-security-blog/os-x-malware-tibet-variant-found/)",
-      "value" : "Artifact used by this malware"
-    },
-    "DevilRobber": {
-      "query" : "select * from launchd where name = 'com.apple.legion.plist' or name = 'com.apple.pixel.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://www.f-secure.com/v-descs/backdoor_osx_devilrobber_a.shtml)",
-      "value" : "Artifact used by this malware"
-    },
-    "XSLCmd": {
-      "query" : "select * from launchd where name = 'com.apple.service.clipboardd.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://www.fireeye.com/blog/threat-research/2014/09/forced-to-adapt-xslcmd-backdoor-now-on-os-x.html)",
-      "value" : "Artifact used by this malware"
-    },
-    "Olyx": {
-      "query" : "select * from launchd where name = 'com.apple.DockActions.plist' or name like '%www. google.com.tstart.plist%';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://www.f-secure.com/v-descs/backdoor_osx_olyx_c.shtml)",
-      "value" : "Artifact used by this malware"
-    },
-    "Imuler": {
-      "query" : "select * from launchd where name = 'checkflr.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://www.f-secure.com/v-descs/backdoor_osx_imuler_a.shtml)",
-      "value" : "Artifact used by this malware"
-    },
-    "iWorkServ": {
-      "query" : "select * from startup_items where path like '%iWorkServices%';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://www.f-secure.com/v-descs/backdoor_osx_iworkserv_a.shtml)",
-      "value" : "Artifact used by this malware"
-    },
-    "Morcut": {
-      "query" : "select * from launchd where name = 'com.apple.mdworker.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.trendmicro.com/vinfo/us/threat-encyclopedia/malware/osx_morcut.a)",
-      "value" : "Artifact used by this malware"
-    },
-    "BlazingKeylogger": {
-      "query" : "select * from launchd where name = 'com.BT.BPK.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.blazingtools.com/mac_keylogger.html)",
-      "value" : "Artifact used by this malware"
-    },
-    "Icefog": {
-      "query" : "select * from launchd where name = 'apple.launchd.plist' or name = 'com.apple.launchport.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://securelist.com/blog/research/57331/the-icefog-apt-a-tale-of-cloak-and-three-daggers/)",
-      "value" : "Artifact used by this malware"
-    },
-    "Careto": {
-      "query" : "select * from launchd where path like '%com.apple.launchport.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://blog.kaspersky.com/the-mask-unveiling-the-worlds-most-sophisticated-apt-campaign/)",
-      "value" : "Artifact used by this malware"
-    },
-    "Inqtana": {
-      "query" : "select * from launchd where name = 'com.pwned.plist' or name = 'com.openbundle.plist' or name = 'com.adobe.reader.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://www.f-secure.com/v-descs/inqtana_a.shtml)",
-      "value" : "Artifact used by this malware"
-    },
-    "MacKontrol": {
-      "query" : "select * from launchd where name = 'com.apple.FolderActionsxl.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://www.f-secure.com/v-descs/backdoor_osx_mackontrol_a.shtml)",
-      "value" : "Artifact used by this malware"
-    },
-    "PubSab": {
-      "query" : "select * from launchd where name = 'com.apple.PubSabAgent.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://www.f-secure.com/v-descs/backdoor_osx_sabpab_a.shtml)",
-      "value" : "Artifact used by this malware"
-    },
-    "Dockster": {
-      "query" : "select * from launchd where name = 'mac.Dockset.deman.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.trendmicro.com/vinfo/us/threat-encyclopedia/malware/osx_dockster.a)",
-      "value" : "Artifact used by this malware"
-    },
-    "CallMe": {
-      "query" : "select * from launchd where name = 'realPlayerUpdate.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://www.f-secure.com/weblog/archives/00002546.html)",
-      "value" : "Artifact used by this malware"
-    },
-    "Whitesmoke": {
-      "query" : "select * from launchd where name = 'com.whitesmoke.uploader.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.thesafemac.com/osxfkcodec-a-in-action/ )",
-      "value" : "Artifact used by this malware"
-    },
-    "Codecm": {
-      "query" : "select * from launchd where name = 'com.codecm.uploader.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.thesafemac.com/osxfkcodec-a-in-action/)",
-      "value" : "Artifact used by this malware"
-    },
-    "iWorm": {
-      "query" : "select * from launchd where name = 'com.JavaW.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://www.virusbtn.com/virusbulletin/archive/2014/10/vb201410-iWorm)",
-      "value" : "Artifact used by this malware"
-    },
-    "iWorm_1": {
-      "query" : "select * from file where path like '/Library/Application Support/JavaW%';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://www.virusbtn.com/virusbulletin/archive/2014/10/vb201410-iWorm)",
-      "value" : "Artifact used by this malware"
-    },
-    "SniperSpy": {
-      "query" : "select * from launchd where name = 'com.rxs.syslogagent.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.symantec.com/security_response/writeup.jsp?docid=2010-081606-4034-99&tabid=2)",
-      "value" : "Artifact used by this malware"
-    },
-    "Vsearch": {
-      "query" : "select * from launchd where          name = 'com.vsearch.agent.plist' OR          name = 'com.vsearch.daemon.plist' OR          name = 'com.vsearch.helper.plist' OR          name = 'Jack.plist' OR          program_arguments = '/etc/run_upd.sh' OR          program_arguments LIKE '/Library/Application Support/%/Agent/agent.app/Contents/MacOS/agent%';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.thesafemac.com/arg-downlite/)",
-      "value" : "Artifact used by this malware"
-    },
-    "Buca": {
-      "query" : "select * from launchd where name = 'com.webhelper.plist' or name = 'com.webtools.update.agent.plist' or name = 'com.webtools.uninstaller.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.thesafemac.com/arg-buca-apps/)",
-      "value" : "Artifact used by this malware"
-    },
-    "Conduit": {
-      "query" : "select * from launchd where path like '%com.conduit.loader.agent.plist' or name = 'com.conduit.loader.agent.plist' or path like '%com.perion.searchprotectd.plist' or name = 'com.perion.searchprotectd.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.thesafemac.com/arg-conduit/)",
-      "value" : "Artifact used by this malware"
-    },
-    "Genieo": {
-      "query" : "select * from launchd where          name = 'com.genieo.completer.download.plist' OR          name = 'com.genieo.completer.update.plist' OR          name = 'com.genieo.completer.ltvbit.plist' OR          name = 'com.installer.completer.download.plist' OR          name = 'com.installer.completer.update.plist' OR          name = 'com.installer.completer.ltvbit.plist' OR          name = 'com.genieoinnovation.macextension.plist' OR          name = 'com.genieoinnovation.macextension.client.plist' OR          name = 'com.genieo.engine.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(http://www.thesafemac.com/arg-genieo/)",
-      "value" : "Artifact used by this malware"
-    },
-    "GenieoPart2": {
-      "query" : "select * from launchd where program_arguments like '/Users/%/Library/Application Support/%/%.app/Contents/MacOS/App% -trigger download -isDev % -installVersion % -firstAppId % -identity %';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "New version of Genieo",
-      "value" : "Artifact used by this malware"
-    },
-    "HackingTeam_Mac_RAT1": {
-      "query" : "select * from file where path = '/dev/ptmx0';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "Detect RAT used by Hacking Team",
-      "value" : "Artifact used by this malware"
-    },
-    "HackingTeam_Mac_RAT2": {
-      "query" : "select * from apps where bundle_identifier = 'com.ht.RCSMac';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "Detect RAT used by Hacking Team",
-      "value" : "Artifact used by this malware"
-    },
-    "HackingTeam_Mac_RAT3": {
-      "query" : "select * from launchd where          label = 'com.ht.RCSMac' OR          name = 'com.apple.loginStoreagent.plist' OR          name = 'com.apple.mdworker.plist' OR          name = 'com.apple.UIServerLogin.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "Detect RAT used by Hacking Team",
-      "value" : "Artifact used by this malware"
-    },
-    "HackingTeam_Mac_Persistence": {
-      "query": "select * from file where directory like '/Users/%/Library/Preferences/8pHbqThW%';",
+    "Aobo_Keylogger": {
+      "description": "(http://aobo.cc/aobo-mac-os-x-keylogger.html)",
       "interval": "3600",
-      "version": "1.4.5",
-      "description": "Detection persistency by Hacking Team",
-      "value": "Artifact used by Hacking Team"
-    },
-    "xprotect_reports": {
-      "query": "select * from xprotect_reports;",
-      "interval": 1200,
-      "removed": false,
-      "version": "1.4.5",
-      "description": "Report on Apple/OS X XProtect 'report' generation. Reports are generated when OS X matches an item in xprotect_entries.",
-      "value": "Although XProtect reports are rare, they may be worth collecting and aggregating internally."
-    },
-    "Keranger_1": {
-      "query": "select * from processes where name = 'kernel_service';",
-      "interval": "3600",
-      "version": "1.4.5",
-      "description": "http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/",
-      "value": "Artifact used by this malware"
-    },
-    "Keranger_2": {
-      "query": "select * from file where          path LIKE '/Users/%/Library/.kernel_%' OR          path LIKE '/Users/%/Library/kernel_service';",
-      "interval": "3600",
-      "version": "1.4.5",
-      "description": "http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/",
-      "value": "Artifact used by this malware"
-    },
-    "PremierOpinion": {
-      "query": "select * from launchd where name = 'PremierOpinion.plist' or name = 'PremierOpinionAgent.plist';",
-      "interval": "3600",
-      "version": "1.4.5",
-      "description": "(http://www.thesafemac.com/arg-premier-opinion/)",
-      "value": "Artifact used by this malware"
-    },
-    "Bundlore": {
-      "query": "select * from launchd where name like 'com.WebShoppy.%.plist' or name like 'com.SoftwareUpdater.%.plist' or name like 'cinema-plus%.plist' or name like 'com.WebTools.%.plist' or name like 'com.crossrider.%.plist' or name like 'shopy-mate_%.plist' or name like 'com.WebShopper.%.plist';",
-      "interval": "3600",
-      "version": "1.4.5",
-      "description": "(http://www.thesafemac.com/arg-bundlore/)",
-      "value": "Artifact used by this malware"
-    },
-    "Spigot": {
-      "query": "select * from launchd where name like 'com.spigot.%.plist';",
-      "interval": "3600",
-      "version": "1.4.5",
-      "description": "(http://www.thesafemac.com/arg-spigot/)",
-      "value": "Artifact used by this malware"
-    },
-    "SearchInstUpdater": {
-      "query": "select * from launchd where name like 'com.updater.mc%.plist' or name like 'com.updater.watch.mc%.plist';",
-      "interval": "3600",
-      "version": "1.4.5",
-      "description": "(https://www.virustotal.com/en/file/9530d481f7bb07aac98a46357bfcff96e2936a90571b4629ae865a2ce63e5c8e/analysis/)",
-      "value": "Artifact used by this malware"
-    },
-    "OSX_Pirrit": {
-      "query": "select * from plist where path = '/Library/Preferences/com.common.plist' and key = 'net_pref';",
-      "interval": "3600",
-      "version": "1.4.5",
-      "description": "(https://threatpost.com/mac-adware-osx-pirrit-unleashes-ad-overload-for-now/117273/)",
-      "value": "Artifact used by this malware"
+      "query": "select * from launchd where name like 'com.ab.kl%.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
     },
     "Backdoor_MAC_Eleanor": {
-      "query": "SELECT * FROM launchd WHERE name IN ('com.getdropbox.dropbox.integritycheck.plist','com.getdropbox.dropbox.timegrabber.plist','com.getdropbox.dropbox.usercontent.plist');",
-      "interval": "3600",
-      "version": "1.4.5",
       "description": "(https://blog.malwarebytes.com/cybercrime/2016/07/new-mac-backdoor-malware-eleanor/)",
-      "value": "Artifact used by this malware"
-    },
-    "EliteKeylogger": {
-      "query": "select * from launchd where name = 'com.apple.fonts.plist' and label = 'unknown';",
       "interval": "3600",
-      "version": "1.4.5",
-      "description": "(https://www.elitekeyloggers.com/elite-keylogger-mac)",
-      "value": "Artifact used by this malware"
-    },
-    "Aobo_Keylogger": {
-      "query": "select * from launchd where name like 'com.ab.kl%.plist';",
-      "interval": "3600",
-      "version": "1.4.5",
-      "description": "(http://aobo.cc/aobo-mac-os-x-keylogger.html)",
-      "value": "Artifact used by this malware"
-    },
-    "OSX_Keydnap": {
-      "query": "select * from launchd where name IN ('com.apple.iCloud.sync.daemon', 'com.geticloud.icloud.photo');",
-      "interval": "3600",
-      "version": "1.4.5",
-      "description": "(http://www.welivesecurity.com/2016/07/06/new-osxkeydnap-malware-hungry-credentials)",
-      "value": "Artifact used by this malware"
-    },
-    "Java_Adwind_Trojan": {
-      "query": "select * from launchd where name like 'org.%.plist' and program_arguments like '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java -Dapple.awt.UIElement=true -jar /Users/%/.%';",
-      "interval": "3600",
-      "version": "1.4.5",
-      "description": "(https://blog.malwarebytes.com/threat-analysis/2016/07/cross-platform-malware-adwind-infects-mac/)",
-      "value": "Artifact used by this malware"
-    },
-    "OSX_Backdoor_Mokes": {
-      "query": "select * from file where          path LIKE '/Users/%/Library/App Store/storeuserd' OR          path LIKE '/Users/%/Library/com.apple.spotlight/SpotlightHelper' OR          path LIKE '/Users/%/Library/Dock/com.apple.dock.cache' OR          path LIKE '/Users/%/Library/Dropbox/DropboxCache' OR          path LIKE '/Users/%/Library/Skype/SkypeHelper' OR          path LIKE '/Users/%/Library/Google/Chrome/nacld' OR          path LIKE '/Users/%/Library/Firefox/Profiles/profiled';",
-      "interval": "3600",
-      "version": "1.4.5",
-      "description": "(https://securelist.com/blog/research/75990/the-missing-piece-sophisticated-os-x-backdoor-discovered/)",
-      "value": "Artifact used by this malware"
-    },
-    "OSX_Komplex": {
-      "query": "select * from file where path = '/Users/Shared/.local/kext' or path = '/Users/Shared/com.apple.updates.plist' or path = '/Users/Shared/start.sh';",
-      "interval": "3600",
-      "version": "1.4.5",
-      "description": "(http://researchcenter.paloaltonetworks.com/2016/09/unit42-sofacys-komplex-os-x-trojan/)",
-      "value": "Artifact used by this malware"
-    },
-    "OceanLotus_launchagent": {
-      "query" : "select * from launchd where name = 'com.google.plugins.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "OceanLotus Launch Agent (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "OceanLotus_dropped_file_1": {
-      "query" : "select * from file, (          select '/Library/Logs/.Logs/corevideosd' ioc union          select '/Library/.SystemPreferences/.prev/.ver.txt' ioc union          select '/Library/Parallels/.cfg' ioc union          select '/Library/Preferences/.fDTYuRs' ioc union          select '/Library/Hash/.Hashtag/.hash' ioc union          select '/Library/Hash/.hash' ioc        ) iocs where          file.path LIKE '/Users/%/' || ioc OR          file.path = iocs.ioc OR          file.path LIKE '/tmp/crunzip.temp.%';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "XcodeGhost": {
-      "query" : "select * from (          select apps.bundle_short_version as xcode_version,            apps.path as xcode_path,            file.path,            file.type as file_type          from apps, file          where apps.bundle_name='Xcode' and            file.path like (apps.path || '/Contents/Developer/Platforms/%/Developer/SDKs/Library/%%')        ) join hash using (path) where file_type = 'regular';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "Xcode Ghost dropped files (http://researchcenter.paloaltonetworks.com/2015/09/novel-malware-xcodeghost-modifies-xcode-infects-apple-ios-apps-and-hits-app-store/)",
-      "value" : "Artifact used by this malware"
-    },
-    "Quimitchin_Backdoor": {
-      "query" : "select * from launchd where name = 'com.client.client.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "Quimitchin Launch Agent (https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/)",
-      "value" : "Artifact used by this malware"
-    },
-    "Pronto": {
-      "query" : "select * from launchd where name = 'pronto.notification.plist' or name = 'pronto.update.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "ProntoApp Launch Agents (https://malwarefixes.com/remove-pronto-video-converter/)",
-      "value" : "Artifact used by this malware"
-    },
-    "OSX_DOK_1": {
-      "query" : "select * from launchd where name = 'com.apple.Safari.proxy.plist' or name = 'com.apple.Safari.proxy.pac';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "DOK Launch Agents (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
-      "value" : "Artifact used by this malware"
-    },
-    "OSX_DOK_2": {
-      "query" : "select common_name, sha1, subject_key_id from certificates where subject_key_id = 'e637d656f9f088ddca3b3b55c4fe698d8c97a552';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "DOK certificate (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
-      "value" : "Artifact used by this malware"
-    },
-    "OSX_DOK_3": {
-      "query" : "select * from file where path = '/Users/Shared/AppStore.app';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "DOK dropped file (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
-      "value" : "Artifact used by this malware"
-    },
-    "OSX_DOK_4": {
-      "query" : "select * from apps where bundle_name = 'Truesteer.AppStore';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "DOK malicious app (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
-      "value" : "Artifact used by this malware"
-    },
-    "OSX_Snake": {
-      "query" : "select * from file           where path = '/Library/LaunchDaemons/com.adobe.update.plist' OR             path = '/Library/Scripts/installd.sh' OR             path = '/Library/Scripts/queue' OR             path = '/tmp/.gdm-socket' OR             path = '/tmp/.gdm-selinux' OR             path LIKE '/var/tmp/.ur-%%';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "OS X port of Snake malware discovered by Fox-IT (https://blog.fox-it.com/2017/05/03/snake-coming-soon-in-mac-os-x-flavour/)",
-      "value" : "Artifacts created by this malware"
-    },
-    "OSX_Proton_Files": {
-      "query" : "select * from file          where path like '/Users/%/Library/RenderFiles/activity_agent.app/' OR          path like '/Users/%/Library/LaunchAgents/fr.handbrake.activity_agent.plist' OR          path='/tmp/Updater.app' OR path='/Library/.rand/updateragent.app' OR          path='/Library/LaunchAgents/com.apple.xpcd.plist' OR          path='/Library/.cachedir' OR          path='/Library/.random';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "OSX/Proton bundled with a tampered version of Handbrake and Elmedia Player: (https://objective-see.com/blog/blog_0x1D.html and https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
-      "value" : "Artifacts created by this malware"
-    },
-    "OSX_Proton_Launchd": {
-      "query" : "select * from launchd where name='com.Eltima.UpdaterAgent.plist' OR name='com.apple.xpcd.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "OSX/Proton bundled with a tampered version of Elmedia Player or Fake Symantec Blog: (https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/) and (https://blog.malwarebytes.com/threat-analysis/mac-threat-analysis/2017/11/osx-proton-spreading-through-fake-symantec-blog/)",
-      "value" : "Artifacts created by this malware"
-    },
-    "OSX_Proton_Process": {
-      "query" : "select * from processes          where path like '/Users/%/Library/RenderFiles/activity_agent.app/Contents/MacOS/activity_agent' OR          path='/Library/.rand/updateragent.app/Contents/MacOS/updateragent' OR          path='/Library/.random/xpcd.app/Contents/MacOS/xpcd';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "OSX/Proton bundled with a tampered version of Handbrake and Elmedia Player: (https://objective-see.com/blog/blog_0x1D.html and https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
-      "value" : "Artifacts created by this malware"
-    },
-    "EmPyre_Agent": {
-      "query" : "select * from launchd where name = 'com.proxy.initialize.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "EmPyre post exploitation agent (https://github.com/EmpireProject/EmPyre/blob/master/lib/modules/persistence/osx/launchdaemonexecutable.py)",
-      "value" : "Artifacts created by this malware"
-    },
-    "OSX_FruitFly": {
-      "query" : "select * from launchd where name = 'com.client.client.plist';",
-      "interval" : "3600",
-      "version" : "1.4.5",
-      "description" : "FruitFly OSX Malware (https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/)",
-      "value" : "Artifacts created by this malware"
-    },
-    "OSX_Mughthesec": {
-      "query" : "select * from launchd where name = 'com.Mughthesec.plist';",
-      "interval" : "3600",
-      "version" : "1.4.5",
-      "description" : "Mughthesec OSX Malware (https://objective-see.com/blog/blog_0x20.html)",
-      "value" : "Artifacts created by this malware"
-    },
-    "OSX_HiddenLotus": {
-      "query" : "select * from launchd where name = 'com.apple.hidd.shared.plist';",
-      "interval" : "3600",
-      "version" : "1.4.5",
-      "description" : "Apple added XProtect rules for this sample: (https://www.virustotal.com/en/file/f261815905e77eebdb5c4ec06a7acdda7b68644b1f5155049f133be866d8b179/analysis/1509567775/)",
-      "value" : "Artifacts created by this malware"
-    },
-    "OSX_MaMi_DNS_Servers": {
-      "query" : "select * from dns_resolvers where type = 'nameserver' and address in ('82.163.143.135', '82.163.142.137');",
-      "interval" : "3600",
-      "version" : "2.8.0",
-      "description" : "MaMi OSX Malware 2017-01-12 (https://objective-see.com/blog/blog_0x26.html)",
-      "value" : "DNS Servers set by this malware"
-    },
-    "OSX_MaMi_Certificate": {
-      "query" : "select * from certificates where common_name like '%cloudguard.me%' and not_valid_after = '2352216315';",
-      "interval" : "3600",
-      "version" : "2.8.0",
-      "description" : "MaMi OSX Malware 2017-01-12 (https://objective-see.com/blog/blog_0x26.html)",
-      "value" : "bogus certificate added to key store by this malware"
+      "query": "SELECT * FROM launchd WHERE name IN ('com.getdropbox.dropbox.integritycheck.plist','com.getdropbox.dropbox.timegrabber.plist','com.getdropbox.dropbox.usercontent.plist');",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
     },
     "Behavioral_Reverse_Shell": {
-      "query" : "SELECT DISTINCT(processes.pid), processes.parent, processes.name, processes.path,          processes.cmdline, processes.cwd, processes.root, processes.uid, processes.gid,          processes.start_time, process_open_sockets.remote_address, process_open_sockets.remote_port,          (SELECT cmdline FROM processes AS parent_cmdline WHERE pid=processes.parent) AS parent_cmdline          FROM processes JOIN process_open_sockets USING (pid)          LEFT OUTER JOIN process_open_files          ON processes.pid = process_open_files.pid          WHERE (name='sh' OR name='bash')          AND process_open_files.pid IS NULL;",
-      "interval" : "3600",
-      "version" : "2.8.0",
-      "description" : "Find shell processes that have open sockets and no open files or TTY (https://clo.ng/blog/osquery_reverse_shell/)",
-      "value" : "Behavioral detection for potential reverse shells"
+      "description": "Find shell processes that have open sockets and no open files or TTY (https://clo.ng/blog/osquery_reverse_shell/)",
+      "interval": "3600",
+      "query": "SELECT DISTINCT(processes.pid), processes.parent, processes.name, processes.path,          processes.cmdline, processes.cwd, processes.root, processes.uid, processes.gid,          processes.start_time, process_open_sockets.remote_address, process_open_sockets.remote_port,          (SELECT cmdline FROM processes AS parent_cmdline WHERE pid=processes.parent) AS parent_cmdline          FROM processes JOIN process_open_sockets USING (pid)          LEFT OUTER JOIN process_open_files          ON processes.pid = process_open_files.pid          WHERE (name='sh' OR name='bash')          AND process_open_files.pid IS NULL;",
+      "value": "Behavioral detection for potential reverse shells",
+      "version": "2.8.0"
     },
-    "OSX_ColdRoot_RAT_Launchd": {
-      "query" : "select * from launchd where name = 'com.apple.audio.driver.plist';",
-      "interval" : "3600",
-      "version" : "1.4.5",
-      "description" : "ColdRoot OSX Malware (https://objective-see.com/blog/blog_0x2A.html)",
-      "value" : "Artifacts created by this malware"
+    "BlazingKeylogger": {
+      "description": "(http://www.blazingtools.com/mac_keylogger.html)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.BT.BPK.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
     },
-    "OSX_ColdRoot_RAT_Files": {
-      "query" : "select * from file          where path in ('/private/var/tmp/com.apple.audio.driver.app/',          '/private/var/tmp/com.apple.audio.driver.app/Contents/MacOS/conx.wol');",
-      "interval" : "3600",
-      "version" : "1.4.5",
-      "description" : "ColdRoot OSX Malware (https://objective-see.com/blog/blog_0x2A.html)",
-      "value" : "Artifacts created by this malware"
+    "Buca": {
+      "description": "(http://www.thesafemac.com/arg-buca-apps/)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.webhelper.plist' or name = 'com.webtools.update.agent.plist' or name = 'com.webtools.uninstaller.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
     },
-    "MacSearch_Adware": {
-      "query": "SELECT * FROM launchd WHERE path='/Library/LaunchAgents/tapufind.plist';",
-      "interval" : "3600",
-      "version" : "1.4.5",
-      "description" : "MacSearch OSX Adware (https://www.virustotal.com/latest-scan/15966224C4E25C9787A4A8C984A863E9)",
-      "value" : "Artifacts created by this adware"
+    "Bundlore": {
+      "description": "(http://www.thesafemac.com/arg-bundlore/)",
+      "interval": "3600",
+      "query": "select * from launchd where name like 'com.WebShoppy.%.plist' or name like 'com.SoftwareUpdater.%.plist' or name like 'cinema-plus%.plist' or name like 'com.WebTools.%.plist' or name like 'com.crossrider.%.plist' or name like 'shopy-mate_%.plist' or name like 'com.WebShopper.%.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
     },
-    "OSX_Dummy_Launchd": {
-      "query": "SELECT * FROM launchd WHERE name = 'com.startup.plist';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html and https://isc.sans.edu/diary/23816)",
-      "value": "Artifacts created by this malware"
+    "CallMe": {
+      "description": "(https://www.f-secure.com/weblog/archives/00002546.html)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'realPlayerUpdate.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
     },
-    "OSX_Dummy_Files": {
-      "query" : "SELECT * FROM file           WHERE path = '/Library/LaunchDaemons/com.startup.plist' OR             path = '/var/root/script.sh' OR             path = '/Users/Shared/dumpdummy' OR             path = '/tmp/script.sh' OR             path = '/tmp/com.startup.plist' OR             path = '/tmp/dumpdummy';",
-      "interval" : "3600",
-      "version": "1.4.5",
-      "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html and https://isc.sans.edu/diary/23816)",
-      "value": "Artifacts created by this malware"
+    "Careto": {
+      "description": "(http://blog.kaspersky.com/the-mask-unveiling-the-worlds-most-sophisticated-apt-campaign/)",
+      "interval": "3600",
+      "query": "select * from launchd where path like '%com.apple.launchport.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Codecm": {
+      "description": "(http://www.thesafemac.com/osxfkcodec-a-in-action/)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.codecm.uploader.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Conduit": {
+      "description": "(http://www.thesafemac.com/arg-conduit/)",
+      "interval": "3600",
+      "query": "select * from launchd where path like '%com.conduit.loader.agent.plist' or name = 'com.conduit.loader.agent.plist' or path like '%com.perion.searchprotectd.plist' or name = 'com.perion.searchprotectd.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "DevilRobber": {
+      "description": "(https://www.f-secure.com/v-descs/backdoor_osx_devilrobber_a.shtml)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.apple.legion.plist' or name = 'com.apple.pixel.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Dockster": {
+      "description": "(http://www.trendmicro.com/vinfo/us/threat-encyclopedia/malware/osx_dockster.a)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'mac.Dockset.deman.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "EliteKeylogger": {
+      "description": "(https://www.elitekeyloggers.com/elite-keylogger-mac)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.apple.fonts.plist' and label = 'unknown';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "EmPyre_Agent": {
+      "description": "EmPyre post exploitation agent (https://github.com/EmpireProject/EmPyre/blob/master/lib/modules/persistence/osx/launchdaemonexecutable.py)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.proxy.initialize.plist';",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
+    },
+    "Genieo": {
+      "description": "(http://www.thesafemac.com/arg-genieo/)",
+      "interval": "3600",
+      "query": "select * from launchd where          name = 'com.genieo.completer.download.plist' OR          name = 'com.genieo.completer.update.plist' OR          name = 'com.genieo.completer.ltvbit.plist' OR          name = 'com.installer.completer.download.plist' OR          name = 'com.installer.completer.update.plist' OR          name = 'com.installer.completer.ltvbit.plist' OR          name = 'com.genieoinnovation.macextension.plist' OR          name = 'com.genieoinnovation.macextension.client.plist' OR          name = 'com.genieo.engine.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "GenieoPart2": {
+      "description": "New version of Genieo",
+      "interval": "3600",
+      "query": "select * from launchd where program_arguments like '/Users/%/Library/Application Support/%/%.app/Contents/MacOS/App% -trigger download -isDev % -installVersion % -firstAppId % -identity %';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "HackingTeam_Mac_Persistence": {
+      "description": "Detection persistency by Hacking Team",
+      "interval": "3600",
+      "query": "select * from file where directory like '/Users/%/Library/Preferences/8pHbqThW%';",
+      "value": "Artifact used by Hacking Team",
+      "version": "1.4.5"
+    },
+    "HackingTeam_Mac_RAT1": {
+      "description": "Detect RAT used by Hacking Team",
+      "interval": "3600",
+      "query": "select * from file where path = '/dev/ptmx0';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "HackingTeam_Mac_RAT2": {
+      "description": "Detect RAT used by Hacking Team",
+      "interval": "3600",
+      "query": "select * from apps where bundle_identifier = 'com.ht.RCSMac';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "HackingTeam_Mac_RAT3": {
+      "description": "Detect RAT used by Hacking Team",
+      "interval": "3600",
+      "query": "select * from launchd where          label = 'com.ht.RCSMac' OR          name = 'com.apple.loginStoreagent.plist' OR          name = 'com.apple.mdworker.plist' OR          name = 'com.apple.UIServerLogin.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Icefog": {
+      "description": "(http://securelist.com/blog/research/57331/the-icefog-apt-a-tale-of-cloak-and-three-daggers/)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'apple.launchd.plist' or name = 'com.apple.launchport.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Imuler": {
+      "description": "(https://www.f-secure.com/v-descs/backdoor_osx_imuler_a.shtml)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'checkflr.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Inqtana": {
+      "description": "(https://www.f-secure.com/v-descs/inqtana_a.shtml)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.pwned.plist' or name = 'com.openbundle.plist' or name = 'com.adobe.reader.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Java_Adwind_Trojan": {
+      "description": "(https://blog.malwarebytes.com/threat-analysis/2016/07/cross-platform-malware-adwind-infects-mac/)",
+      "interval": "3600",
+      "query": "select * from launchd where name like 'org.%.plist' and program_arguments like '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java -Dapple.awt.UIElement=true -jar /Users/%/.%';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Keranger_1": {
+      "description": "http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/",
+      "interval": "3600",
+      "query": "select * from processes where name = 'kernel_service';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Keranger_2": {
+      "description": "http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/",
+      "interval": "3600",
+      "query": "select * from file where          path LIKE '/Users/%/Library/.kernel_%' OR          path LIKE '/Users/%/Library/kernel_service';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
     },
     "Keyboard_Event_Taps": {
-      "query": "SELECT * FROM processes JOIN event_taps ON processes.pid = event_taps.tapping_process where event_taps.enabled = 1;",
-      "interval" : "3600",
-      "version": "3.3.0",
       "description": "Finds processes that have active keyboard event taps, typically used by RATs and other malicious software for keylogging",
-      "value": "Process with keyboard event taps"
+      "interval": "3600",
+      "query": "SELECT * FROM processes JOIN event_taps ON processes.pid = event_taps.tapping_process where event_taps.enabled = 1;",
+      "value": "Process with keyboard event taps",
+      "version": "3.3.0"
+    },
+    "Leverage-A_1": {
+      "description": "(http://www.intego.com/mac-security-blog/new-mac-trojan-discovered-related-to-syria/)",
+      "interval": "3600",
+      "query": "select * from launchd where path like '%UserEvent.System.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Leverage-A_2": {
+      "description": "(http://www.intego.com/mac-security-blog/new-mac-trojan-discovered-related-to-syria/)",
+      "interval": "3600",
+      "query": "select * from file where path = '/Users/Shared/UserEvent.app';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Leverage-A_3": {
+      "description": "(https://www.volexity.com/blog/2017/07/24/real-news-fake-flash-mac-os-x-users-targeted/)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.GetFlashPlayer.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "MacKontrol": {
+      "description": "(https://www.f-secure.com/v-descs/backdoor_osx_mackontrol_a.shtml)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.apple.FolderActionsxl.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "MacSearch_Adware": {
+      "description": "MacSearch OSX Adware (https://www.virustotal.com/latest-scan/15966224C4E25C9787A4A8C984A863E9)",
+      "interval": "3600",
+      "query": "SELECT * FROM launchd WHERE path='/Library/LaunchAgents/tapufind.plist';",
+      "value": "Artifacts created by this adware",
+      "version": "1.4.5"
+    },
+    "Morcut": {
+      "description": "(http://www.trendmicro.com/vinfo/us/threat-encyclopedia/malware/osx_morcut.a)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.apple.mdworker.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_Backdoor_Mokes": {
+      "description": "(https://securelist.com/blog/research/75990/the-missing-piece-sophisticated-os-x-backdoor-discovered/)",
+      "interval": "3600",
+      "query": "select * from file where          path LIKE '/Users/%/Library/App Store/storeuserd' OR          path LIKE '/Users/%/Library/com.apple.spotlight/SpotlightHelper' OR          path LIKE '/Users/%/Library/Dock/com.apple.dock.cache' OR          path LIKE '/Users/%/Library/Dropbox/DropboxCache' OR          path LIKE '/Users/%/Library/Skype/SkypeHelper' OR          path LIKE '/Users/%/Library/Google/Chrome/nacld' OR          path LIKE '/Users/%/Library/Firefox/Profiles/profiled';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_ColdRoot_RAT_Files": {
+      "description": "ColdRoot OSX Malware (https://objective-see.com/blog/blog_0x2A.html)",
+      "interval": "3600",
+      "query": "select * from file          where path in ('/private/var/tmp/com.apple.audio.driver.app/',          '/private/var/tmp/com.apple.audio.driver.app/Contents/MacOS/conx.wol');",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_ColdRoot_RAT_Launchd": {
+      "description": "ColdRoot OSX Malware (https://objective-see.com/blog/blog_0x2A.html)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.apple.audio.driver.plist';",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_DOK_1": {
+      "description": "DOK Launch Agents (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.apple.Safari.proxy.plist' or name = 'com.apple.Safari.proxy.pac';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_DOK_2": {
+      "description": "DOK certificate (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
+      "interval": "3600",
+      "query": "select common_name, sha1, subject_key_id from certificates where subject_key_id = 'e637d656f9f088ddca3b3b55c4fe698d8c97a552';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_DOK_3": {
+      "description": "DOK dropped file (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
+      "interval": "3600",
+      "query": "select * from file where path = '/Users/Shared/AppStore.app';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_DOK_4": {
+      "description": "DOK malicious app (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
+      "interval": "3600",
+      "query": "select * from apps where bundle_name = 'Truesteer.AppStore';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_Dummy_Files": {
+      "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html and https://isc.sans.edu/diary/23816)",
+      "interval": "3600",
+      "query": "SELECT * FROM file           WHERE path = '/Library/LaunchDaemons/com.startup.plist' OR             path = '/var/root/script.sh' OR             path = '/Users/Shared/dumpdummy' OR             path = '/tmp/script.sh' OR             path = '/tmp/com.startup.plist' OR             path = '/tmp/dumpdummy';",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_Dummy_Launchd": {
+      "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html and https://isc.sans.edu/diary/23816)",
+      "interval": "3600",
+      "query": "SELECT * FROM launchd WHERE name = 'com.startup.plist';",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_FruitFly": {
+      "description": "FruitFly OSX Malware (https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.client.client.plist';",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_HiddenLotus": {
+      "description": "Apple added XProtect rules for this sample: (https://www.virustotal.com/en/file/f261815905e77eebdb5c4ec06a7acdda7b68644b1f5155049f133be866d8b179/analysis/1509567775/)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.apple.hidd.shared.plist';",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_Keydnap": {
+      "description": "(http://www.welivesecurity.com/2016/07/06/new-osxkeydnap-malware-hungry-credentials)",
+      "interval": "3600",
+      "query": "select * from launchd where name IN ('com.apple.iCloud.sync.daemon', 'com.geticloud.icloud.photo');",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_Komplex": {
+      "description": "(http://researchcenter.paloaltonetworks.com/2016/09/unit42-sofacys-komplex-os-x-trojan/)",
+      "interval": "3600",
+      "query": "select * from file where path = '/Users/Shared/.local/kext' or path = '/Users/Shared/com.apple.updates.plist' or path = '/Users/Shared/start.sh';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_MaMi_Certificate": {
+      "description": "MaMi OSX Malware 2017-01-12 (https://objective-see.com/blog/blog_0x26.html)",
+      "interval": "3600",
+      "query": "select * from certificates where common_name like '%cloudguard.me%' and not_valid_after = '2352216315';",
+      "value": "bogus certificate added to key store by this malware",
+      "version": "2.8.0"
+    },
+    "OSX_MaMi_DNS_Servers": {
+      "description": "MaMi OSX Malware 2017-01-12 (https://objective-see.com/blog/blog_0x26.html)",
+      "interval": "3600",
+      "query": "select * from dns_resolvers where type = 'nameserver' and address in ('82.163.143.135', '82.163.142.137');",
+      "value": "DNS Servers set by this malware",
+      "version": "2.8.0"
+    },
+    "OSX_Mughthesec": {
+      "description": "Mughthesec OSX Malware (https://objective-see.com/blog/blog_0x20.html)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.Mughthesec.plist';",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_Pirrit": {
+      "description": "(https://threatpost.com/mac-adware-osx-pirrit-unleashes-ad-overload-for-now/117273/)",
+      "interval": "3600",
+      "query": "select * from plist where path = '/Library/Preferences/com.common.plist' and key = 'net_pref';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_Proton_Files": {
+      "description": "OSX/Proton bundled with a tampered version of Handbrake and Elmedia Player: (https://objective-see.com/blog/blog_0x1D.html and https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
+      "interval": "3600",
+      "query": "select * from file          where path like '/Users/%/Library/RenderFiles/activity_agent.app/' OR          path like '/Users/%/Library/LaunchAgents/fr.handbrake.activity_agent.plist' OR          path='/tmp/Updater.app' OR path='/Library/.rand/updateragent.app' OR          path='/Library/LaunchAgents/com.apple.xpcd.plist' OR          path='/Library/.cachedir' OR          path='/Library/.random';",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_Proton_Launchd": {
+      "description": "OSX/Proton bundled with a tampered version of Elmedia Player or Fake Symantec Blog: (https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/) and (https://blog.malwarebytes.com/threat-analysis/mac-threat-analysis/2017/11/osx-proton-spreading-through-fake-symantec-blog/)",
+      "interval": "3600",
+      "query": "select * from launchd where name='com.Eltima.UpdaterAgent.plist' OR name='com.apple.xpcd.plist';",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_Proton_Process": {
+      "description": "OSX/Proton bundled with a tampered version of Handbrake and Elmedia Player: (https://objective-see.com/blog/blog_0x1D.html and https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
+      "interval": "3600",
+      "query": "select * from processes          where path like '/Users/%/Library/RenderFiles/activity_agent.app/Contents/MacOS/activity_agent' OR          path='/Library/.rand/updateragent.app/Contents/MacOS/updateragent' OR          path='/Library/.random/xpcd.app/Contents/MacOS/xpcd';",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
     },
     "OSX_SearchAwesome": {
-      "query" : "SELECT * FROM file           WHERE path = '/Applications/spi.app' OR             path = '/Users/%/Library/LaunchAgents/spid-uninstall.plist' OR             path = '/Users/%/Library/LaunchAgents/spid.plist' OR             path = '/Users/%/Library/SPI';",
-      "interval" : "3600",
-      "version": "1.4.5",
       "description": "OSX SearchAwesome Malware (https://blog.malwarebytes.com/threat-analysis/2018/10/mac-malware-intercepts-encrypted-web-traffic-for-ad-injection/)",
-      "value": "Artifacts created by this malware"
+      "interval": "3600",
+      "query": "SELECT * FROM file           WHERE path = '/Applications/spi.app' OR             path = '/Users/%/Library/LaunchAgents/spid-uninstall.plist' OR             path = '/Users/%/Library/LaunchAgents/spid.plist' OR             path = '/Users/%/Library/SPI';",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
+    },
+    "OSX_Snake": {
+      "description": "OS X port of Snake malware discovered by Fox-IT (https://blog.fox-it.com/2017/05/03/snake-coming-soon-in-mac-os-x-flavour/)",
+      "interval": "3600",
+      "query": "select * from file           where path = '/Library/LaunchDaemons/com.adobe.update.plist' OR             path = '/Library/Scripts/installd.sh' OR             path = '/Library/Scripts/queue' OR             path = '/tmp/.gdm-socket' OR             path = '/tmp/.gdm-selinux' OR             path LIKE '/var/tmp/.ur-%%';",
+      "value": "Artifacts created by this malware",
+      "version": "1.4.5"
+    },
+    "OceanLotus_dropped_file_1": {
+      "description": "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
+      "interval": "3600",
+      "query": "select * from file, (          select '/Library/Logs/.Logs/corevideosd' ioc union          select '/Library/.SystemPreferences/.prev/.ver.txt' ioc union          select '/Library/Parallels/.cfg' ioc union          select '/Library/Preferences/.fDTYuRs' ioc union          select '/Library/Hash/.Hashtag/.hash' ioc union          select '/Library/Hash/.hash' ioc        ) iocs where          file.path LIKE '/Users/%/' || ioc OR          file.path = iocs.ioc OR          file.path LIKE '/tmp/crunzip.temp.%';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "OceanLotus_launchagent": {
+      "description": "OceanLotus Launch Agent (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.google.plugins.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Olyx": {
+      "description": "(https://www.f-secure.com/v-descs/backdoor_osx_olyx_c.shtml)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.apple.DockActions.plist' or name like '%www. google.com.tstart.plist%';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "PremierOpinion": {
+      "description": "(http://www.thesafemac.com/arg-premier-opinion/)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'PremierOpinion.plist' or name = 'PremierOpinionAgent.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Pronto": {
+      "description": "ProntoApp Launch Agents (https://malwarefixes.com/remove-pronto-video-converter/)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'pronto.notification.plist' or name = 'pronto.update.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "PubSab": {
+      "description": "(https://www.f-secure.com/v-descs/backdoor_osx_sabpab_a.shtml)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.apple.PubSabAgent.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Quimitchin_Backdoor": {
+      "description": "Quimitchin Launch Agent (https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.client.client.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "SearchInstUpdater": {
+      "description": "(https://www.virustotal.com/en/file/9530d481f7bb07aac98a46357bfcff96e2936a90571b4629ae865a2ce63e5c8e/analysis/)",
+      "interval": "3600",
+      "query": "select * from launchd where name like 'com.updater.mc%.plist' or name like 'com.updater.watch.mc%.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "SniperSpy": {
+      "description": "(http://www.symantec.com/security_response/writeup.jsp?docid=2010-081606-4034-99&tabid=2)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.rxs.syslogagent.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Spigot": {
+      "description": "(http://www.thesafemac.com/arg-spigot/)",
+      "interval": "3600",
+      "query": "select * from launchd where name like 'com.spigot.%.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Tibet.D": {
+      "description": "(http://www.intego.com/mac-security-blog/os-x-malware-tibet-variant-found/)",
+      "interval": "3600",
+      "query": "select * from launchd where path like '%com.apple.AudioService.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Vsearch": {
+      "description": "(http://www.thesafemac.com/arg-downlite/)",
+      "interval": "3600",
+      "query": "select * from launchd where          name = 'com.vsearch.agent.plist' OR          name = 'com.vsearch.daemon.plist' OR          name = 'com.vsearch.helper.plist' OR          name = 'Jack.plist' OR          program_arguments = '/etc/run_upd.sh' OR          program_arguments LIKE '/Library/Application Support/%/Agent/agent.app/Contents/MacOS/agent%';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "Whitesmoke": {
+      "description": "(http://www.thesafemac.com/osxfkcodec-a-in-action/ )",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.whitesmoke.uploader.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "WireLurker": {
+      "description": "(https://github.com/PaloAltoNetworks-BD/WireLurkerDetector)",
+      "interval": "3600",
+      "query": "select * from launchd where          name = 'com.apple.machook_damon.plist' OR          name = 'com.apple.globalupdate.plist' OR          name = 'com.apple.appstore.plughelper.plist' OR          name = 'com.apple.MailServiceAgentHelper.plist' OR          name = 'com.apple.systemkeychain-helper.plist' OR          name = 'com.apple.periodic-dd-mm-yy.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "XSLCmd": {
+      "description": "(https://www.fireeye.com/blog/threat-research/2014/09/forced-to-adapt-xslcmd-backdoor-now-on-os-x.html)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.apple.service.clipboardd.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "XcodeGhost": {
+      "description": "Xcode Ghost dropped files (http://researchcenter.paloaltonetworks.com/2015/09/novel-malware-xcodeghost-modifies-xcode-infects-apple-ios-apps-and-hits-app-store/)",
+      "interval": "3600",
+      "query": "select * from (          select apps.bundle_short_version as xcode_version,            apps.path as xcode_path,            file.path,            file.type as file_type          from apps, file          where apps.bundle_name='Xcode' and            file.path like (apps.path || '/Contents/Developer/Platforms/%/Developer/SDKs/Library/%%')        ) join hash using (path) where file_type = 'regular';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "iWorkServ": {
+      "description": "(https://www.f-secure.com/v-descs/backdoor_osx_iworkserv_a.shtml)",
+      "interval": "3600",
+      "query": "select * from startup_items where path like '%iWorkServices%';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "iWorm": {
+      "description": "(https://www.virusbtn.com/virusbulletin/archive/2014/10/vb201410-iWorm)",
+      "interval": "3600",
+      "query": "select * from launchd where name = 'com.JavaW.plist';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "iWorm_1": {
+      "description": "(https://www.virusbtn.com/virusbulletin/archive/2014/10/vb201410-iWorm)",
+      "interval": "3600",
+      "query": "select * from file where path like '/Library/Application Support/JavaW%';",
+      "value": "Artifact used by this malware",
+      "version": "1.4.5"
+    },
+    "xprotect_reports": {
+      "description": "Report on Apple/OS X XProtect 'report' generation. Reports are generated when OS X matches an item in xprotect_entries.",
+      "interval": 1200,
+      "query": "select * from xprotect_reports;",
+      "removed": false,
+      "value": "Although XProtect reports are rare, they may be worth collecting and aggregating internally.",
+      "version": "1.4.5"
     }
   }
 }

--- a/output/packs/osx-attacks.conf
+++ b/output/packs/osx-attacks.conf
@@ -2,13 +2,7 @@
   "platform": "darwin",
   "queries": {
     "WireLurker": {
-      "query" : "select * from launchd where \
-        name = 'com.apple.machook_damon.plist' OR \
-        name = 'com.apple.globalupdate.plist' OR \
-        name = 'com.apple.appstore.plughelper.plist' OR \
-        name = 'com.apple.MailServiceAgentHelper.plist' OR \
-        name = 'com.apple.systemkeychain-helper.plist' OR \
-        name = 'com.apple.periodic-dd-mm-yy.plist';",
+      "query" : "select * from launchd where          name = 'com.apple.machook_damon.plist' OR          name = 'com.apple.globalupdate.plist' OR          name = 'com.apple.appstore.plughelper.plist' OR          name = 'com.apple.MailServiceAgentHelper.plist' OR          name = 'com.apple.systemkeychain-helper.plist' OR          name = 'com.apple.periodic-dd-mm-yy.plist';",
       "interval" : "3600",
       "version": "1.4.5",
       "description" : "(https://github.com/PaloAltoNetworks-BD/WireLurkerDetector)",
@@ -176,13 +170,7 @@
       "value" : "Artifact used by this malware"
     },
     "Vsearch": {
-      "query" : "select * from launchd where \
-        name = 'com.vsearch.agent.plist' OR \
-        name = 'com.vsearch.daemon.plist' OR \
-        name = 'com.vsearch.helper.plist' OR \
-        name = 'Jack.plist' OR \
-        program_arguments = '/etc/run_upd.sh' OR \
-        program_arguments LIKE '/Library/Application Support/%/Agent/agent.app/Contents/MacOS/agent%';",
+      "query" : "select * from launchd where          name = 'com.vsearch.agent.plist' OR          name = 'com.vsearch.daemon.plist' OR          name = 'com.vsearch.helper.plist' OR          name = 'Jack.plist' OR          program_arguments = '/etc/run_upd.sh' OR          program_arguments LIKE '/Library/Application Support/%/Agent/agent.app/Contents/MacOS/agent%';",
       "interval" : "3600",
       "version": "1.4.5",
       "description" : "(http://www.thesafemac.com/arg-downlite/)",
@@ -203,16 +191,7 @@
       "value" : "Artifact used by this malware"
     },
     "Genieo": {
-      "query" : "select * from launchd where \
-        name = 'com.genieo.completer.download.plist' OR \
-        name = 'com.genieo.completer.update.plist' OR \
-        name = 'com.genieo.completer.ltvbit.plist' OR \
-        name = 'com.installer.completer.download.plist' OR \
-        name = 'com.installer.completer.update.plist' OR \
-        name = 'com.installer.completer.ltvbit.plist' OR \
-        name = 'com.genieoinnovation.macextension.plist' OR \
-        name = 'com.genieoinnovation.macextension.client.plist' OR \
-        name = 'com.genieo.engine.plist';",
+      "query" : "select * from launchd where          name = 'com.genieo.completer.download.plist' OR          name = 'com.genieo.completer.update.plist' OR          name = 'com.genieo.completer.ltvbit.plist' OR          name = 'com.installer.completer.download.plist' OR          name = 'com.installer.completer.update.plist' OR          name = 'com.installer.completer.ltvbit.plist' OR          name = 'com.genieoinnovation.macextension.plist' OR          name = 'com.genieoinnovation.macextension.client.plist' OR          name = 'com.genieo.engine.plist';",
       "interval" : "3600",
       "version": "1.4.5",
       "description" : "(http://www.thesafemac.com/arg-genieo/)",
@@ -240,11 +219,7 @@
       "value" : "Artifact used by this malware"
     },
     "HackingTeam_Mac_RAT3": {
-      "query" : "select * from launchd where \
-        label = 'com.ht.RCSMac' OR \
-        name = 'com.apple.loginStoreagent.plist' OR \
-        name = 'com.apple.mdworker.plist' OR \
-        name = 'com.apple.UIServerLogin.plist';",
+      "query" : "select * from launchd where          label = 'com.ht.RCSMac' OR          name = 'com.apple.loginStoreagent.plist' OR          name = 'com.apple.mdworker.plist' OR          name = 'com.apple.UIServerLogin.plist';",
       "interval" : "3600",
       "version": "1.4.5",
       "description" : "Detect RAT used by Hacking Team",
@@ -273,9 +248,7 @@
       "value": "Artifact used by this malware"
     },
     "Keranger_2": {
-      "query": "select * from file where \
-        path LIKE '/Users/%/Library/.kernel_%' OR \
-        path LIKE '/Users/%/Library/kernel_service';",
+      "query": "select * from file where          path LIKE '/Users/%/Library/.kernel_%' OR          path LIKE '/Users/%/Library/kernel_service';",
       "interval": "3600",
       "version": "1.4.5",
       "description": "http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/",
@@ -352,14 +325,7 @@
       "value": "Artifact used by this malware"
     },
     "OSX_Backdoor_Mokes": {
-      "query": "select * from file where \
-        path LIKE '/Users/%/Library/App Store/storeuserd' OR \
-        path LIKE '/Users/%/Library/com.apple.spotlight/SpotlightHelper' OR \
-        path LIKE '/Users/%/Library/Dock/com.apple.dock.cache' OR \
-        path LIKE '/Users/%/Library/Dropbox/DropboxCache' OR \
-        path LIKE '/Users/%/Library/Skype/SkypeHelper' OR \
-        path LIKE '/Users/%/Library/Google/Chrome/nacld' OR \
-        path LIKE '/Users/%/Library/Firefox/Profiles/profiled';",
+      "query": "select * from file where          path LIKE '/Users/%/Library/App Store/storeuserd' OR          path LIKE '/Users/%/Library/com.apple.spotlight/SpotlightHelper' OR          path LIKE '/Users/%/Library/Dock/com.apple.dock.cache' OR          path LIKE '/Users/%/Library/Dropbox/DropboxCache' OR          path LIKE '/Users/%/Library/Skype/SkypeHelper' OR          path LIKE '/Users/%/Library/Google/Chrome/nacld' OR          path LIKE '/Users/%/Library/Firefox/Profiles/profiled';",
       "interval": "3600",
       "version": "1.4.5",
       "description": "(https://securelist.com/blog/research/75990/the-missing-piece-sophisticated-os-x-backdoor-discovered/)",
@@ -380,32 +346,14 @@
       "value" : "Artifact used by this malware"
     },
     "OceanLotus_dropped_file_1": {
-      "query" : "select * from file, ( \
-        select '/Library/Logs/.Logs/corevideosd' ioc union \
-        select '/Library/.SystemPreferences/.prev/.ver.txt' ioc union \
-        select '/Library/Parallels/.cfg' ioc union \
-        select '/Library/Preferences/.fDTYuRs' ioc union \
-        select '/Library/Hash/.Hashtag/.hash' ioc union \
-        select '/Library/Hash/.hash' ioc \
-      ) iocs where \
-        file.path LIKE '/Users/%/' || ioc OR \
-        file.path = iocs.ioc OR \
-        file.path LIKE '/tmp/crunzip.temp.%';",
+      "query" : "select * from file, (          select '/Library/Logs/.Logs/corevideosd' ioc union          select '/Library/.SystemPreferences/.prev/.ver.txt' ioc union          select '/Library/Parallels/.cfg' ioc union          select '/Library/Preferences/.fDTYuRs' ioc union          select '/Library/Hash/.Hashtag/.hash' ioc union          select '/Library/Hash/.hash' ioc        ) iocs where          file.path LIKE '/Users/%/' || ioc OR          file.path = iocs.ioc OR          file.path LIKE '/tmp/crunzip.temp.%';",
       "interval" : "3600",
       "version": "1.4.5",
       "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
       "value" : "Artifact used by this malware"
     },
     "XcodeGhost": {
-      "query" : "select * from ( \
-        select apps.bundle_short_version as xcode_version, \
-          apps.path as xcode_path, \
-          file.path, \
-          file.type as file_type \
-        from apps, file \
-        where apps.bundle_name='Xcode' and \
-          file.path like (apps.path || '/Contents/Developer/Platforms/%/Developer/SDKs/Library/%%') \
-      ) join hash using (path) where file_type = 'regular';",
+      "query" : "select * from (          select apps.bundle_short_version as xcode_version,            apps.path as xcode_path,            file.path,            file.type as file_type          from apps, file          where apps.bundle_name='Xcode' and            file.path like (apps.path || '/Contents/Developer/Platforms/%/Developer/SDKs/Library/%%')        ) join hash using (path) where file_type = 'regular';",
       "interval" : "3600",
       "version": "1.4.5",
       "description" : "Xcode Ghost dropped files (http://researchcenter.paloaltonetworks.com/2015/09/novel-malware-xcodeghost-modifies-xcode-infects-apple-ios-apps-and-hits-app-store/)",
@@ -454,26 +402,14 @@
       "value" : "Artifact used by this malware"
     },
     "OSX_Snake": {
-      "query" : "select * from file \
-         where path = '/Library/LaunchDaemons/com.adobe.update.plist' OR \
-           path = '/Library/Scripts/installd.sh' OR \
-           path = '/Library/Scripts/queue' OR \
-           path = '/tmp/.gdm-socket' OR \
-           path = '/tmp/.gdm-selinux' OR \
-           path LIKE '/var/tmp/.ur-%%';",
+      "query" : "select * from file           where path = '/Library/LaunchDaemons/com.adobe.update.plist' OR             path = '/Library/Scripts/installd.sh' OR             path = '/Library/Scripts/queue' OR             path = '/tmp/.gdm-socket' OR             path = '/tmp/.gdm-selinux' OR             path LIKE '/var/tmp/.ur-%%';",
       "interval" : "3600",
       "version": "1.4.5",
       "description" : "OS X port of Snake malware discovered by Fox-IT (https://blog.fox-it.com/2017/05/03/snake-coming-soon-in-mac-os-x-flavour/)",
       "value" : "Artifacts created by this malware"
     },
     "OSX_Proton_Files": {
-      "query" : "select * from file \
-        where path like '/Users/%/Library/RenderFiles/activity_agent.app/' OR \
-        path like '/Users/%/Library/LaunchAgents/fr.handbrake.activity_agent.plist' OR \
-        path='/tmp/Updater.app' OR path='/Library/.rand/updateragent.app' OR \
-        path='/Library/LaunchAgents/com.apple.xpcd.plist' OR \
-        path='/Library/.cachedir' OR \
-        path='/Library/.random';",
+      "query" : "select * from file          where path like '/Users/%/Library/RenderFiles/activity_agent.app/' OR          path like '/Users/%/Library/LaunchAgents/fr.handbrake.activity_agent.plist' OR          path='/tmp/Updater.app' OR path='/Library/.rand/updateragent.app' OR          path='/Library/LaunchAgents/com.apple.xpcd.plist' OR          path='/Library/.cachedir' OR          path='/Library/.random';",
       "interval" : "3600",
       "version": "1.4.5",
       "description" : "OSX/Proton bundled with a tampered version of Handbrake and Elmedia Player: (https://objective-see.com/blog/blog_0x1D.html and https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
@@ -487,10 +423,7 @@
       "value" : "Artifacts created by this malware"
     },
     "OSX_Proton_Process": {
-      "query" : "select * from processes \
-        where path like '/Users/%/Library/RenderFiles/activity_agent.app/Contents/MacOS/activity_agent' OR \
-        path='/Library/.rand/updateragent.app/Contents/MacOS/updateragent' OR \
-        path='/Library/.random/xpcd.app/Contents/MacOS/xpcd';",
+      "query" : "select * from processes          where path like '/Users/%/Library/RenderFiles/activity_agent.app/Contents/MacOS/activity_agent' OR          path='/Library/.rand/updateragent.app/Contents/MacOS/updateragent' OR          path='/Library/.random/xpcd.app/Contents/MacOS/xpcd';",
       "interval" : "3600",
       "version": "1.4.5",
       "description" : "OSX/Proton bundled with a tampered version of Handbrake and Elmedia Player: (https://objective-see.com/blog/blog_0x1D.html and https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
@@ -539,15 +472,7 @@
       "value" : "bogus certificate added to key store by this malware"
     },
     "Behavioral_Reverse_Shell": {
-      "query" : "SELECT DISTINCT(processes.pid), processes.parent, processes.name, processes.path, \
-        processes.cmdline, processes.cwd, processes.root, processes.uid, processes.gid, \
-        processes.start_time, process_open_sockets.remote_address, process_open_sockets.remote_port, \
-        (SELECT cmdline FROM processes AS parent_cmdline WHERE pid=processes.parent) AS parent_cmdline \
-        FROM processes JOIN process_open_sockets USING (pid) \
-        LEFT OUTER JOIN process_open_files \
-        ON processes.pid = process_open_files.pid \
-        WHERE (name='sh' OR name='bash') \
-        AND process_open_files.pid IS NULL;",
+      "query" : "SELECT DISTINCT(processes.pid), processes.parent, processes.name, processes.path,          processes.cmdline, processes.cwd, processes.root, processes.uid, processes.gid,          processes.start_time, process_open_sockets.remote_address, process_open_sockets.remote_port,          (SELECT cmdline FROM processes AS parent_cmdline WHERE pid=processes.parent) AS parent_cmdline          FROM processes JOIN process_open_sockets USING (pid)          LEFT OUTER JOIN process_open_files          ON processes.pid = process_open_files.pid          WHERE (name='sh' OR name='bash')          AND process_open_files.pid IS NULL;",
       "interval" : "3600",
       "version" : "2.8.0",
       "description" : "Find shell processes that have open sockets and no open files or TTY (https://clo.ng/blog/osquery_reverse_shell/)",
@@ -561,9 +486,7 @@
       "value" : "Artifacts created by this malware"
     },
     "OSX_ColdRoot_RAT_Files": {
-      "query" : "select * from file \
-        where path in ('/private/var/tmp/com.apple.audio.driver.app/', \
-        '/private/var/tmp/com.apple.audio.driver.app/Contents/MacOS/conx.wol');",
+      "query" : "select * from file          where path in ('/private/var/tmp/com.apple.audio.driver.app/',          '/private/var/tmp/com.apple.audio.driver.app/Contents/MacOS/conx.wol');",
       "interval" : "3600",
       "version" : "1.4.5",
       "description" : "ColdRoot OSX Malware (https://objective-see.com/blog/blog_0x2A.html)",
@@ -584,13 +507,7 @@
       "value": "Artifacts created by this malware"
     },
     "OSX_Dummy_Files": {
-      "query" : "SELECT * FROM file \
-         WHERE path = '/Library/LaunchDaemons/com.startup.plist' OR \
-           path = '/var/root/script.sh' OR \
-           path = '/Users/Shared/dumpdummy' OR \
-           path = '/tmp/script.sh' OR \
-           path = '/tmp/com.startup.plist' OR \
-           path = '/tmp/dumpdummy';",
+      "query" : "SELECT * FROM file           WHERE path = '/Library/LaunchDaemons/com.startup.plist' OR             path = '/var/root/script.sh' OR             path = '/Users/Shared/dumpdummy' OR             path = '/tmp/script.sh' OR             path = '/tmp/com.startup.plist' OR             path = '/tmp/dumpdummy';",
       "interval" : "3600",
       "version": "1.4.5",
       "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html and https://isc.sans.edu/diary/23816)",
@@ -604,11 +521,7 @@
       "value": "Process with keyboard event taps"
     },
     "OSX_SearchAwesome": {
-      "query" : "SELECT * FROM file \
-         WHERE path = '/Applications/spi.app' OR \
-           path = '/Users/%/Library/LaunchAgents/spid-uninstall.plist' OR \
-           path = '/Users/%/Library/LaunchAgents/spid.plist' OR \
-           path = '/Users/%/Library/SPI';",
+      "query" : "SELECT * FROM file           WHERE path = '/Applications/spi.app' OR             path = '/Users/%/Library/LaunchAgents/spid-uninstall.plist' OR             path = '/Users/%/Library/LaunchAgents/spid.plist' OR             path = '/Users/%/Library/SPI';",
       "interval" : "3600",
       "version": "1.4.5",
       "description": "OSX SearchAwesome Malware (https://blog.malwarebytes.com/threat-analysis/2018/10/mac-malware-intercepts-encrypted-web-traffic-for-ad-injection/)",

--- a/output/packs/unwanted-chrome-extensions.conf
+++ b/output/packs/unwanted-chrome-extensions.conf
@@ -1,0 +1,60 @@
+{
+  "platform": "windows,darwin",
+  "queries": {
+    "BetternetVPN": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gjknjjomckknofjidppipffbpoekiipm';",
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
+    },
+    "Chrometana": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
+    },
+    "CopyFish": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='eenjdnjldapjajjofmldgmkjaienebbj';",
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/copyfish-chrome-extension-hijacked-to-show-adware/)"
+    },
+    "Giphy": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
+      "interval": 3600,
+      "description": "(https://www.reddit.com/r/chrome/comments/6htzan/psawarning_giphy_extension_6172017_is_now_malware/)"
+    },
+    "HolaVPN": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gkojfkhlekighikafcpjkiklfbnlmeio';",
+      "interval": 3600,
+      "description": "(http://adios-hola.org)"
+    },
+    "InfinityNewTab": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='dbfmnekepjoapopniengjbcpnbljalfg';",
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
+    },
+    "SocialFixer": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='ifmhoabcaeehkljcfclfiieohkohdgbb';",
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
+    },
+    "TouchVPN": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bihmplhobchoageeokmgbdihknkjbknd';",
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
+    },
+    "WebDeveloper": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bfbameneiokkgbdmiekhjnmfkcnldhhm';",
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/chrome-extension-with-over-one-million-users-hijacked-to-serve-adware/)"
+    },
+    "WebPaint": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='emeokgokialpjadjaoeiplmnkjoaegng';",
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
+    },
+    "MacOSInstallCore": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='hinehnlkkmckjblijjpbpamhljokoohh';",
+      "interval": 3600,
+      "description": "(https://www.virustotal.com/#/file/5cab0821f597100dc1170bfef704d8cebaf67743e9d509e83b0b208eb630d992/detection)"
+    }
+  }
+}

--- a/output/packs/unwanted-chrome-extensions.conf
+++ b/output/packs/unwanted-chrome-extensions.conf
@@ -2,59 +2,59 @@
   "platform": "windows,darwin",
   "queries": {
     "BetternetVPN": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gjknjjomckknofjidppipffbpoekiipm';",
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)",
       "interval": 3600,
-      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gjknjjomckknofjidppipffbpoekiipm';"
     },
     "Chrometana": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)",
       "interval": 3600,
-      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';"
     },
     "CopyFish": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='eenjdnjldapjajjofmldgmkjaienebbj';",
+      "description": "(https://www.bleepingcomputer.com/news/security/copyfish-chrome-extension-hijacked-to-show-adware/)",
       "interval": 3600,
-      "description": "(https://www.bleepingcomputer.com/news/security/copyfish-chrome-extension-hijacked-to-show-adware/)"
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='eenjdnjldapjajjofmldgmkjaienebbj';"
     },
     "Giphy": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
+      "description": "(https://www.reddit.com/r/chrome/comments/6htzan/psawarning_giphy_extension_6172017_is_now_malware/)",
       "interval": 3600,
-      "description": "(https://www.reddit.com/r/chrome/comments/6htzan/psawarning_giphy_extension_6172017_is_now_malware/)"
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';"
     },
     "HolaVPN": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gkojfkhlekighikafcpjkiklfbnlmeio';",
+      "description": "(http://adios-hola.org)",
       "interval": 3600,
-      "description": "(http://adios-hola.org)"
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gkojfkhlekighikafcpjkiklfbnlmeio';"
     },
     "InfinityNewTab": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='dbfmnekepjoapopniengjbcpnbljalfg';",
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)",
       "interval": 3600,
-      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
-    },
-    "SocialFixer": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='ifmhoabcaeehkljcfclfiieohkohdgbb';",
-      "interval": 3600,
-      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
-    },
-    "TouchVPN": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bihmplhobchoageeokmgbdihknkjbknd';",
-      "interval": 3600,
-      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
-    },
-    "WebDeveloper": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bfbameneiokkgbdmiekhjnmfkcnldhhm';",
-      "interval": 3600,
-      "description": "(https://www.bleepingcomputer.com/news/security/chrome-extension-with-over-one-million-users-hijacked-to-serve-adware/)"
-    },
-    "WebPaint": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='emeokgokialpjadjaoeiplmnkjoaegng';",
-      "interval": 3600,
-      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='dbfmnekepjoapopniengjbcpnbljalfg';"
     },
     "MacOSInstallCore": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='hinehnlkkmckjblijjpbpamhljokoohh';",
+      "description": "(https://www.virustotal.com/#/file/5cab0821f597100dc1170bfef704d8cebaf67743e9d509e83b0b208eb630d992/detection)",
       "interval": 3600,
-      "description": "(https://www.virustotal.com/#/file/5cab0821f597100dc1170bfef704d8cebaf67743e9d509e83b0b208eb630d992/detection)"
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='hinehnlkkmckjblijjpbpamhljokoohh';"
+    },
+    "SocialFixer": {
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)",
+      "interval": 3600,
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='ifmhoabcaeehkljcfclfiieohkohdgbb';"
+    },
+    "TouchVPN": {
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)",
+      "interval": 3600,
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bihmplhobchoageeokmgbdihknkjbknd';"
+    },
+    "WebDeveloper": {
+      "description": "(https://www.bleepingcomputer.com/news/security/chrome-extension-with-over-one-million-users-hijacked-to-serve-adware/)",
+      "interval": 3600,
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bfbameneiokkgbdmiekhjnmfkcnldhhm';"
+    },
+    "WebPaint": {
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)",
+      "interval": 3600,
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='emeokgokialpjadjaoeiplmnkjoaegng';"
     }
   }
 }

--- a/output/packs/vuln-management.conf
+++ b/output/packs/vuln-management.conf
@@ -1,0 +1,145 @@
+{
+  "queries": {
+    "kernel_info": {
+      "query" : "select * from kernel_info;",
+      "interval" : "86400",
+      "version" : "1.4.5",
+      "description" : "Retrieves information from the current kernel in the target system.",
+      "value" : "Kernel version can tell you vulnerabilities based on the version"
+    },
+    "os_version": {
+      "query" : "select * from os_version;",
+      "interval" : "86400",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current version of the running osquery in the target system and where the configuration was loaded from.",
+      "value" : "OS version will tell which distribution the OS is running on, allowing to detect the main distribution"
+    },
+    "kextstat": {
+      "query" : "select * from kernel_extensions;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the information about the current kernel extensions for the target OSX system.",
+      "value" : "Only for OS X.  It may pinpoint inserted modules that can carry malicious payloads."
+    },
+    "kernel_modules": {
+      "query" : "select * from kernel_modules;",
+      "interval" : "86400",
+      "platform" : "linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the information for the current kernel modules in the target Linux system.",
+      "value" : "Only for Linux.  It may pinpoint inserted modules that can carry malicious payloads."
+    },
+    "installed_applications": {
+      "query" : "select * from apps;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the currently installed applications in the target OSX system.",
+      "value" : "This, with the help of a vulnerability feed, can help tell if a vulnerable application is installed."
+    },
+    "browser_plugins": {
+      "query" : "select browser_plugins.* from users join browser_plugins using (uid);",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.6.1",
+      "description" : "Retrieves the list of C/NPAPI browser plugins in the target system.",
+      "value" : "General security posture."
+    },
+    "safari_extensions": {
+      "query" : "select safari_extensions.* from users join safari_extensions using (uid);",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.6.1",
+      "description" : "Retrieves the list of extensions for Safari in the target system.",
+      "value" : "General security posture."
+    },
+    "opera_extensions": {
+      "query" : "select opera_extensions.* from users join opera_extensions using (uid);",
+      "interval" : "86400",
+      "platform" : "posix",
+      "version" : "1.6.1",
+      "description" : "Retrieves the list of extensions for Opera in the target system.",
+      "value" : "General security posture."
+    },
+    "chrome_extensions": {
+      "query" : "select chrome_extensions.* from users join chrome_extensions using (uid);",
+      "interval" : "86400",
+      "version" : "1.6.1",
+      "description" : "Retrieves the list of extensions for Chrome in the target system.",
+      "value" : "General security posture."
+    },
+    "firefox_addons": {
+      "query" : "select firefox_addons.* from users join firefox_addons using (uid);",
+      "interval" : "86400",
+      "platform" : "posix",
+      "version" : "1.6.1",
+      "description" : "Retrieves the list of addons for Firefox in the target system.",
+      "value" : "General security posture."
+    },
+    "homebrew_packages": {
+      "query" : "select * from homebrew_packages;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves the list of brew packages installed in the target OSX system.",
+      "value" : "This, with the help of a vulnerability feed, can help tell if a vulnerable application is installed."
+    },
+    "package_receipts": {
+      "query" : "select * from package_receipts;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the PKG related information stored in OSX.",
+      "value" : "It could give you a trail of installed/deleted packages"
+    },
+    "deb_packages": {
+      "query" : "select * from deb_packages;",
+      "interval" : "86400",
+      "platform" : "linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the installed DEB packages in the target Linux system.",
+      "value" : "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed."
+    },
+    "apt_sources": {
+      "query" : "select * from apt_sources;",
+      "interval" : "86400",
+      "platform" : "linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the APT sources to install packages from in the target Linux system.",
+      "value" : "In the future this may not have a lot of value as we expect to have installed only signed packages"
+    },
+    "portage_packages": {
+      "query" : "select * from portage_packages;",
+      "interval" : "86400",
+      "platform" : "linux",
+      "version" : "2.0.0",
+      "description" : "Retrieves all the installed packages on the target Linux system.",
+      "value" : "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed."
+    },
+    "rpm_packages": {
+      "query" : "select * from rpm_packages;",
+      "interval" : "86400",
+      "platform" : "linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the installed RPM packages in the target Linux system.",
+      "value" : "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed."
+    },
+    "unauthenticated_sparkle_feeds": {
+      "query" : "select feeds.*, p2.value as sparkle_version from (select a.name as app_name, a.path as app_path, a.bundle_identifier as bundle_id, p.value as feed_url from (select name, path, bundle_identifier from apps) a, plist p where p.path = a.path || '/Contents/Info.plist' and p.key = 'SUFeedURL' and feed_url like 'http://%') feeds left outer join plist p2 on p2.path = app_path || '/Contents/Frameworks/Sparkle.framework/Resources/Info.plist' where (p2.key = 'CFBundleShortVersionString' OR coalesce(p2.key, '') = '');",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all application bundles using unauthenticated Sparkle update feeds. See (https://vulnsec.com/2016/osx-apps-vulnerabilities/) for details.",
+      "value" : "Tracking vulnerable applications updates may allow blocking of DNS or removal by BundleID."
+    },
+    "backdoored_python_packages": {
+      "query" : "select name as package_name, version as package_version, path as package_path from python_packages where package_name = 'acqusition' or package_name = 'apidev-coop' or package_name = 'bzip' or package_name = 'crypt' or package_name = 'django-server' or package_name = 'pwd' or package_name = 'setup-tools' or package_name = 'telnet' or package_name = 'urlib3' or package_name = 'urllib';",
+      "interval" : "86400",
+      "platform" : "posix",
+      "version" : "1.4.5",
+      "description" : "Watches for the backdoored Python packages installed on system. See (http://www.nbu.gov.sk/skcsirt-sa-20170909-pypi/index.html)",
+      "value" : "Gives some assurances that no bad Python packages are installed on the system."
+    }
+  }
+}

--- a/output/packs/vuln-management.conf
+++ b/output/packs/vuln-management.conf
@@ -1,145 +1,145 @@
 {
   "queries": {
-    "kernel_info": {
-      "query" : "select * from kernel_info;",
-      "interval" : "86400",
-      "version" : "1.4.5",
-      "description" : "Retrieves information from the current kernel in the target system.",
-      "value" : "Kernel version can tell you vulnerabilities based on the version"
-    },
-    "os_version": {
-      "query" : "select * from os_version;",
-      "interval" : "86400",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current version of the running osquery in the target system and where the configuration was loaded from.",
-      "value" : "OS version will tell which distribution the OS is running on, allowing to detect the main distribution"
-    },
-    "kextstat": {
-      "query" : "select * from kernel_extensions;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the information about the current kernel extensions for the target OSX system.",
-      "value" : "Only for OS X.  It may pinpoint inserted modules that can carry malicious payloads."
-    },
-    "kernel_modules": {
-      "query" : "select * from kernel_modules;",
-      "interval" : "86400",
-      "platform" : "linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the information for the current kernel modules in the target Linux system.",
-      "value" : "Only for Linux.  It may pinpoint inserted modules that can carry malicious payloads."
-    },
-    "installed_applications": {
-      "query" : "select * from apps;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the currently installed applications in the target OSX system.",
-      "value" : "This, with the help of a vulnerability feed, can help tell if a vulnerable application is installed."
-    },
-    "browser_plugins": {
-      "query" : "select browser_plugins.* from users join browser_plugins using (uid);",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.6.1",
-      "description" : "Retrieves the list of C/NPAPI browser plugins in the target system.",
-      "value" : "General security posture."
-    },
-    "safari_extensions": {
-      "query" : "select safari_extensions.* from users join safari_extensions using (uid);",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.6.1",
-      "description" : "Retrieves the list of extensions for Safari in the target system.",
-      "value" : "General security posture."
-    },
-    "opera_extensions": {
-      "query" : "select opera_extensions.* from users join opera_extensions using (uid);",
-      "interval" : "86400",
-      "platform" : "posix",
-      "version" : "1.6.1",
-      "description" : "Retrieves the list of extensions for Opera in the target system.",
-      "value" : "General security posture."
-    },
-    "chrome_extensions": {
-      "query" : "select chrome_extensions.* from users join chrome_extensions using (uid);",
-      "interval" : "86400",
-      "version" : "1.6.1",
-      "description" : "Retrieves the list of extensions for Chrome in the target system.",
-      "value" : "General security posture."
-    },
-    "firefox_addons": {
-      "query" : "select firefox_addons.* from users join firefox_addons using (uid);",
-      "interval" : "86400",
-      "platform" : "posix",
-      "version" : "1.6.1",
-      "description" : "Retrieves the list of addons for Firefox in the target system.",
-      "value" : "General security posture."
-    },
-    "homebrew_packages": {
-      "query" : "select * from homebrew_packages;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves the list of brew packages installed in the target OSX system.",
-      "value" : "This, with the help of a vulnerability feed, can help tell if a vulnerable application is installed."
-    },
-    "package_receipts": {
-      "query" : "select * from package_receipts;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the PKG related information stored in OSX.",
-      "value" : "It could give you a trail of installed/deleted packages"
-    },
-    "deb_packages": {
-      "query" : "select * from deb_packages;",
-      "interval" : "86400",
-      "platform" : "linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the installed DEB packages in the target Linux system.",
-      "value" : "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed."
-    },
     "apt_sources": {
-      "query" : "select * from apt_sources;",
-      "interval" : "86400",
-      "platform" : "linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the APT sources to install packages from in the target Linux system.",
-      "value" : "In the future this may not have a lot of value as we expect to have installed only signed packages"
-    },
-    "portage_packages": {
-      "query" : "select * from portage_packages;",
-      "interval" : "86400",
-      "platform" : "linux",
-      "version" : "2.0.0",
-      "description" : "Retrieves all the installed packages on the target Linux system.",
-      "value" : "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed."
-    },
-    "rpm_packages": {
-      "query" : "select * from rpm_packages;",
-      "interval" : "86400",
-      "platform" : "linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the installed RPM packages in the target Linux system.",
-      "value" : "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed."
-    },
-    "unauthenticated_sparkle_feeds": {
-      "query" : "select feeds.*, p2.value as sparkle_version from (select a.name as app_name, a.path as app_path, a.bundle_identifier as bundle_id, p.value as feed_url from (select name, path, bundle_identifier from apps) a, plist p where p.path = a.path || '/Contents/Info.plist' and p.key = 'SUFeedURL' and feed_url like 'http://%') feeds left outer join plist p2 on p2.path = app_path || '/Contents/Frameworks/Sparkle.framework/Resources/Info.plist' where (p2.key = 'CFBundleShortVersionString' OR coalesce(p2.key, '') = '');",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all application bundles using unauthenticated Sparkle update feeds. See (https://vulnsec.com/2016/osx-apps-vulnerabilities/) for details.",
-      "value" : "Tracking vulnerable applications updates may allow blocking of DNS or removal by BundleID."
+      "description": "Retrieves all the APT sources to install packages from in the target Linux system.",
+      "interval": "86400",
+      "platform": "linux",
+      "query": "select * from apt_sources;",
+      "value": "In the future this may not have a lot of value as we expect to have installed only signed packages",
+      "version": "1.4.5"
     },
     "backdoored_python_packages": {
-      "query" : "select name as package_name, version as package_version, path as package_path from python_packages where package_name = 'acqusition' or package_name = 'apidev-coop' or package_name = 'bzip' or package_name = 'crypt' or package_name = 'django-server' or package_name = 'pwd' or package_name = 'setup-tools' or package_name = 'telnet' or package_name = 'urlib3' or package_name = 'urllib';",
-      "interval" : "86400",
-      "platform" : "posix",
-      "version" : "1.4.5",
-      "description" : "Watches for the backdoored Python packages installed on system. See (http://www.nbu.gov.sk/skcsirt-sa-20170909-pypi/index.html)",
-      "value" : "Gives some assurances that no bad Python packages are installed on the system."
+      "description": "Watches for the backdoored Python packages installed on system. See (http://www.nbu.gov.sk/skcsirt-sa-20170909-pypi/index.html)",
+      "interval": "86400",
+      "platform": "posix",
+      "query": "select name as package_name, version as package_version, path as package_path from python_packages where package_name = 'acqusition' or package_name = 'apidev-coop' or package_name = 'bzip' or package_name = 'crypt' or package_name = 'django-server' or package_name = 'pwd' or package_name = 'setup-tools' or package_name = 'telnet' or package_name = 'urlib3' or package_name = 'urllib';",
+      "value": "Gives some assurances that no bad Python packages are installed on the system.",
+      "version": "1.4.5"
+    },
+    "browser_plugins": {
+      "description": "Retrieves the list of C/NPAPI browser plugins in the target system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select browser_plugins.* from users join browser_plugins using (uid);",
+      "value": "General security posture.",
+      "version": "1.6.1"
+    },
+    "chrome_extensions": {
+      "description": "Retrieves the list of extensions for Chrome in the target system.",
+      "interval": "86400",
+      "query": "select chrome_extensions.* from users join chrome_extensions using (uid);",
+      "value": "General security posture.",
+      "version": "1.6.1"
+    },
+    "deb_packages": {
+      "description": "Retrieves all the installed DEB packages in the target Linux system.",
+      "interval": "86400",
+      "platform": "linux",
+      "query": "select * from deb_packages;",
+      "value": "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed.",
+      "version": "1.4.5"
+    },
+    "firefox_addons": {
+      "description": "Retrieves the list of addons for Firefox in the target system.",
+      "interval": "86400",
+      "platform": "posix",
+      "query": "select firefox_addons.* from users join firefox_addons using (uid);",
+      "value": "General security posture.",
+      "version": "1.6.1"
+    },
+    "homebrew_packages": {
+      "description": "Retrieves the list of brew packages installed in the target OSX system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from homebrew_packages;",
+      "value": "This, with the help of a vulnerability feed, can help tell if a vulnerable application is installed.",
+      "version": "1.4.5"
+    },
+    "installed_applications": {
+      "description": "Retrieves all the currently installed applications in the target OSX system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from apps;",
+      "value": "This, with the help of a vulnerability feed, can help tell if a vulnerable application is installed.",
+      "version": "1.4.5"
+    },
+    "kernel_info": {
+      "description": "Retrieves information from the current kernel in the target system.",
+      "interval": "86400",
+      "query": "select * from kernel_info;",
+      "value": "Kernel version can tell you vulnerabilities based on the version",
+      "version": "1.4.5"
+    },
+    "kernel_modules": {
+      "description": "Retrieves all the information for the current kernel modules in the target Linux system.",
+      "interval": "86400",
+      "platform": "linux",
+      "query": "select * from kernel_modules;",
+      "value": "Only for Linux.  It may pinpoint inserted modules that can carry malicious payloads.",
+      "version": "1.4.5"
+    },
+    "kextstat": {
+      "description": "Retrieves all the information about the current kernel extensions for the target OSX system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from kernel_extensions;",
+      "value": "Only for OS X.  It may pinpoint inserted modules that can carry malicious payloads.",
+      "version": "1.4.5"
+    },
+    "opera_extensions": {
+      "description": "Retrieves the list of extensions for Opera in the target system.",
+      "interval": "86400",
+      "platform": "posix",
+      "query": "select opera_extensions.* from users join opera_extensions using (uid);",
+      "value": "General security posture.",
+      "version": "1.6.1"
+    },
+    "os_version": {
+      "description": "Retrieves the current version of the running osquery in the target system and where the configuration was loaded from.",
+      "interval": "86400",
+      "query": "select * from os_version;",
+      "value": "OS version will tell which distribution the OS is running on, allowing to detect the main distribution",
+      "version": "1.4.5"
+    },
+    "package_receipts": {
+      "description": "Retrieves all the PKG related information stored in OSX.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select * from package_receipts;",
+      "value": "It could give you a trail of installed/deleted packages",
+      "version": "1.4.5"
+    },
+    "portage_packages": {
+      "description": "Retrieves all the installed packages on the target Linux system.",
+      "interval": "86400",
+      "platform": "linux",
+      "query": "select * from portage_packages;",
+      "value": "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed.",
+      "version": "2.0.0"
+    },
+    "rpm_packages": {
+      "description": "Retrieves all the installed RPM packages in the target Linux system.",
+      "interval": "86400",
+      "platform": "linux",
+      "query": "select * from rpm_packages;",
+      "value": "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed.",
+      "version": "1.4.5"
+    },
+    "safari_extensions": {
+      "description": "Retrieves the list of extensions for Safari in the target system.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select safari_extensions.* from users join safari_extensions using (uid);",
+      "value": "General security posture.",
+      "version": "1.6.1"
+    },
+    "unauthenticated_sparkle_feeds": {
+      "description": "Retrieves all application bundles using unauthenticated Sparkle update feeds. See (https://vulnsec.com/2016/osx-apps-vulnerabilities/) for details.",
+      "interval": "86400",
+      "platform": "darwin",
+      "query": "select feeds.*, p2.value as sparkle_version from (select a.name as app_name, a.path as app_path, a.bundle_identifier as bundle_id, p.value as feed_url from (select name, path, bundle_identifier from apps) a, plist p where p.path = a.path || '/Contents/Info.plist' and p.key = 'SUFeedURL' and feed_url like 'http://%') feeds left outer join plist p2 on p2.path = app_path || '/Contents/Frameworks/Sparkle.framework/Resources/Info.plist' where (p2.key = 'CFBundleShortVersionString' OR coalesce(p2.key, '') = '');",
+      "value": "Tracking vulnerable applications updates may allow blocking of DNS or removal by BundleID.",
+      "version": "1.4.5"
     }
   }
 }

--- a/output/packs/windows-attacks.conf
+++ b/output/packs/windows-attacks.conf
@@ -1,0 +1,95 @@
+{
+  "platform": "windows",
+  "queries": {
+    "CCleaner_Trojan.Floxif": {
+      "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Piriform\\Agomo%';",
+      "interval" : "3600",
+      "version": "2.2.1",
+      "description" : "(https://sensorstechforum.com/ccleaner-trojan-floxif-malware-how-to-remove/)",
+      "value" : "Artifact used by this malware"
+    },
+    "CCleaner_Trojan_stage2.Floxif": {
+      "query": "select h.md5, h.sha1, h.sha256, s.name, s.service_type, s.display_name, s.module_path, s.user_account from services s, hash h where h.path = s.module_path and ((s.module_path like '%GeeSetup_x86%' and h.sha256 = 'dc9b5e8aa6ec86db8af0a7aa897ca61db3e5f3d2e0942e319074db1aaccfdc83') or (s.module_path like '%EFACli64%' and h.sha256 = '128aca58be325174f0220bd7ca6030e4e206b4378796e82da460055733bb6f4f') or (s.module_path like '%TSMSISrv%' and h.sha256 = '07fb252d2e853a9b1b32f30ede411f2efbb9f01e4a7782db5eacf3f55cf34902'));",
+      "interval" : "3600",
+      "version": "2.1.0",
+      "description" : "(https://sensorstechforum.com/ccleaner-trojan-floxif-malware-how-to-remove/)",
+      "value" : "Artifact used by this malware"
+    },
+    "Winsecurity_info_1": {
+      "query" : "select * from programs where name = 'Winsecurity.info';",
+      "interval" : "3600",
+      "version": "2.2.1",
+      "description" : "(https://sensorstechforum.com/windows-infected-2-viruses-scam-remove/)",
+      "value" : "Artifact used by this malware"
+    },
+    "Winsecurity_info_2": {
+      "query" : "select * from chrome_extensions join users using (uid) where name = 'Winsecurity.info';",
+      "interval" : "3600",
+      "version": "2.2.1",
+      "description" : "(https://sensorstechforum.com/windows-infected-2-viruses-scam-remove/)",
+      "value" : "Artifact used by this malware"
+    },
+    "unTabs_1": {
+      "query" : "select * from programs where name like 'unTabs%';",
+      "interval" : "3600",
+      "version": "2.2.1",
+      "description" : "(https://sensorstechforum.com/untabs-browser-extension-virus-remove-completely/)",
+      "value" : "Artifact used by this malware"
+    },
+    "unTabs_2": {
+      "query" : "select * from chrome_extensions join users using (uid) where name like 'unTabs%';",
+      "interval" : "3600",
+      "version": "2.2.1",
+      "description" : "(https://sensorstechforum.com/untabs-browser-extension-virus-remove-completely/)",
+      "value" : "Artifact used by this malware"
+    },
+    "StickyKeys_File_Replace_Backdoor": {
+      "query": "SELECT * FROM hash WHERE (path='c:\\windows\\system32\\osk.exe' OR path='c:\\windows\\system32\\sethc.exe' OR path='c:\\windows\\system32\\narrator.exe' OR path='c:\\windows\\system32\\magnify.exe' OR path='c:\\windows\\system32\\displayswitch.exe') AND sha256 IN (SELECT sha256 FROM hash WHERE path='c:\\windows\\system32\\cmd.exe' OR path='c:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' OR path='c:\\windows\\system32\\explorer.exe') AND sha256!='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Checks the hashes of accessibility tools to ensure they don't match the hashes of cmd.exe, powershell.exe, or explorer.exe. More info: (https://github.com/TrullJ/sticky-keys-scanner/blob/master/TestFor-StickyKey.ps1)"
+    },
+    "StickyKeys_Registry_Backdoor": {
+      "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%%' and name='Debugger';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Searches for the presence of the 'Debugger' registry key for common Windows accessibility tools. More info: (https://blogs.technet.microsoft.com/jonathantrull/2016/10/03/detecting-sticky-key-backdoors/)"
+    },
+    "conhost.exe_incorrect_path": {
+      "query": "SELECT * FROM processes WHERE LOWER(name)='conhost.exe' AND LOWER(path)!='c:\\windows\\system32\\conhost.exe' AND path!='';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Detect processes masquerading as legitimate Windows processes"
+    },
+    "dllhost.exe_incorrect_path": {
+      "query": "SELECT * FROM processes WHERE LOWER(name)='dllhost.exe' AND LOWER(path)!='c:\\windows\\system32\\dllhost.exe' AND LOWER(path)!='c:\\windows\\syswow64\\dllhost.exe' AND path!='';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Detect processes masquerading as legitimate Windows processes"
+    },
+    "lsass.exe_incorrect_path": {
+      "query": "SELECT * FROM processes WHERE LOWER(name)='lsass.exe' AND LOWER(path)!='c:\\windows\\system32\\lsass.exe' AND path!='';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Detect processes masquerading as legitimate Windows processes"
+    },
+    "services.exe_incorrect_parent_process": {
+      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE LOWER(name)='services.exe') AND LOWER(name)!='wininit.exe';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Detect processes masquerading as legitimate Windows processes"
+    },
+    "svchost.exe_incorrect_path": {
+      "query": "SELECT * FROM processes WHERE LOWER(name)='svchost.exe' AND LOWER(path)!='c:\\windows\\system32\\svchost.exe' AND LOWER(path)!='c:\\windows\\syswow64\\svchost.exe' AND path!='';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Detect processes masquerading as legitimate Windows processes"
+    },
+    "svchost.exe_incorrect_parent_process": {
+      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE LOWER(name)='svchost.exe') AND LOWER(name)!='services.exe';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Detect processes masquerading as legitimate Windows processes"
+    }
+  }
+}

--- a/output/packs/windows-attacks.conf
+++ b/output/packs/windows-attacks.conf
@@ -2,94 +2,94 @@
   "platform": "windows",
   "queries": {
     "CCleaner_Trojan.Floxif": {
-      "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Piriform\\Agomo%';",
-      "interval" : "3600",
-      "version": "2.2.1",
-      "description" : "(https://sensorstechforum.com/ccleaner-trojan-floxif-malware-how-to-remove/)",
-      "value" : "Artifact used by this malware"
+      "description": "(https://sensorstechforum.com/ccleaner-trojan-floxif-malware-how-to-remove/)",
+      "interval": "3600",
+      "query": "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Piriform\\Agomo%';",
+      "value": "Artifact used by this malware",
+      "version": "2.2.1"
     },
     "CCleaner_Trojan_stage2.Floxif": {
+      "description": "(https://sensorstechforum.com/ccleaner-trojan-floxif-malware-how-to-remove/)",
+      "interval": "3600",
       "query": "select h.md5, h.sha1, h.sha256, s.name, s.service_type, s.display_name, s.module_path, s.user_account from services s, hash h where h.path = s.module_path and ((s.module_path like '%GeeSetup_x86%' and h.sha256 = 'dc9b5e8aa6ec86db8af0a7aa897ca61db3e5f3d2e0942e319074db1aaccfdc83') or (s.module_path like '%EFACli64%' and h.sha256 = '128aca58be325174f0220bd7ca6030e4e206b4378796e82da460055733bb6f4f') or (s.module_path like '%TSMSISrv%' and h.sha256 = '07fb252d2e853a9b1b32f30ede411f2efbb9f01e4a7782db5eacf3f55cf34902'));",
-      "interval" : "3600",
-      "version": "2.1.0",
-      "description" : "(https://sensorstechforum.com/ccleaner-trojan-floxif-malware-how-to-remove/)",
-      "value" : "Artifact used by this malware"
-    },
-    "Winsecurity_info_1": {
-      "query" : "select * from programs where name = 'Winsecurity.info';",
-      "interval" : "3600",
-      "version": "2.2.1",
-      "description" : "(https://sensorstechforum.com/windows-infected-2-viruses-scam-remove/)",
-      "value" : "Artifact used by this malware"
-    },
-    "Winsecurity_info_2": {
-      "query" : "select * from chrome_extensions join users using (uid) where name = 'Winsecurity.info';",
-      "interval" : "3600",
-      "version": "2.2.1",
-      "description" : "(https://sensorstechforum.com/windows-infected-2-viruses-scam-remove/)",
-      "value" : "Artifact used by this malware"
-    },
-    "unTabs_1": {
-      "query" : "select * from programs where name like 'unTabs%';",
-      "interval" : "3600",
-      "version": "2.2.1",
-      "description" : "(https://sensorstechforum.com/untabs-browser-extension-virus-remove-completely/)",
-      "value" : "Artifact used by this malware"
-    },
-    "unTabs_2": {
-      "query" : "select * from chrome_extensions join users using (uid) where name like 'unTabs%';",
-      "interval" : "3600",
-      "version": "2.2.1",
-      "description" : "(https://sensorstechforum.com/untabs-browser-extension-virus-remove-completely/)",
-      "value" : "Artifact used by this malware"
+      "value": "Artifact used by this malware",
+      "version": "2.1.0"
     },
     "StickyKeys_File_Replace_Backdoor": {
-      "query": "SELECT * FROM hash WHERE (path='c:\\windows\\system32\\osk.exe' OR path='c:\\windows\\system32\\sethc.exe' OR path='c:\\windows\\system32\\narrator.exe' OR path='c:\\windows\\system32\\magnify.exe' OR path='c:\\windows\\system32\\displayswitch.exe') AND sha256 IN (SELECT sha256 FROM hash WHERE path='c:\\windows\\system32\\cmd.exe' OR path='c:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' OR path='c:\\windows\\system32\\explorer.exe') AND sha256!='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';",
+      "description": "Checks the hashes of accessibility tools to ensure they don't match the hashes of cmd.exe, powershell.exe, or explorer.exe. More info: (https://github.com/TrullJ/sticky-keys-scanner/blob/master/TestFor-StickyKey.ps1)",
       "interval": 3600,
-      "version": "2.2.1",
-      "description": "Checks the hashes of accessibility tools to ensure they don't match the hashes of cmd.exe, powershell.exe, or explorer.exe. More info: (https://github.com/TrullJ/sticky-keys-scanner/blob/master/TestFor-StickyKey.ps1)"
+      "query": "SELECT * FROM hash WHERE (path='c:\\windows\\system32\\osk.exe' OR path='c:\\windows\\system32\\sethc.exe' OR path='c:\\windows\\system32\\narrator.exe' OR path='c:\\windows\\system32\\magnify.exe' OR path='c:\\windows\\system32\\displayswitch.exe') AND sha256 IN (SELECT sha256 FROM hash WHERE path='c:\\windows\\system32\\cmd.exe' OR path='c:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' OR path='c:\\windows\\system32\\explorer.exe') AND sha256!='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';",
+      "version": "2.2.1"
     },
     "StickyKeys_Registry_Backdoor": {
-      "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%%' and name='Debugger';",
+      "description": "Searches for the presence of the 'Debugger' registry key for common Windows accessibility tools. More info: (https://blogs.technet.microsoft.com/jonathantrull/2016/10/03/detecting-sticky-key-backdoors/)",
       "interval": 3600,
-      "version": "2.2.1",
-      "description": "Searches for the presence of the 'Debugger' registry key for common Windows accessibility tools. More info: (https://blogs.technet.microsoft.com/jonathantrull/2016/10/03/detecting-sticky-key-backdoors/)"
+      "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%%' and name='Debugger';",
+      "version": "2.2.1"
+    },
+    "Winsecurity_info_1": {
+      "description": "(https://sensorstechforum.com/windows-infected-2-viruses-scam-remove/)",
+      "interval": "3600",
+      "query": "select * from programs where name = 'Winsecurity.info';",
+      "value": "Artifact used by this malware",
+      "version": "2.2.1"
+    },
+    "Winsecurity_info_2": {
+      "description": "(https://sensorstechforum.com/windows-infected-2-viruses-scam-remove/)",
+      "interval": "3600",
+      "query": "select * from chrome_extensions join users using (uid) where name = 'Winsecurity.info';",
+      "value": "Artifact used by this malware",
+      "version": "2.2.1"
     },
     "conhost.exe_incorrect_path": {
-      "query": "SELECT * FROM processes WHERE LOWER(name)='conhost.exe' AND LOWER(path)!='c:\\windows\\system32\\conhost.exe' AND path!='';",
+      "description": "Detect processes masquerading as legitimate Windows processes",
       "interval": 3600,
-      "version": "2.2.1",
-      "description": "Detect processes masquerading as legitimate Windows processes"
+      "query": "SELECT * FROM processes WHERE LOWER(name)='conhost.exe' AND LOWER(path)!='c:\\windows\\system32\\conhost.exe' AND path!='';",
+      "version": "2.2.1"
     },
     "dllhost.exe_incorrect_path": {
-      "query": "SELECT * FROM processes WHERE LOWER(name)='dllhost.exe' AND LOWER(path)!='c:\\windows\\system32\\dllhost.exe' AND LOWER(path)!='c:\\windows\\syswow64\\dllhost.exe' AND path!='';",
+      "description": "Detect processes masquerading as legitimate Windows processes",
       "interval": 3600,
-      "version": "2.2.1",
-      "description": "Detect processes masquerading as legitimate Windows processes"
+      "query": "SELECT * FROM processes WHERE LOWER(name)='dllhost.exe' AND LOWER(path)!='c:\\windows\\system32\\dllhost.exe' AND LOWER(path)!='c:\\windows\\syswow64\\dllhost.exe' AND path!='';",
+      "version": "2.2.1"
     },
     "lsass.exe_incorrect_path": {
-      "query": "SELECT * FROM processes WHERE LOWER(name)='lsass.exe' AND LOWER(path)!='c:\\windows\\system32\\lsass.exe' AND path!='';",
+      "description": "Detect processes masquerading as legitimate Windows processes",
       "interval": 3600,
-      "version": "2.2.1",
-      "description": "Detect processes masquerading as legitimate Windows processes"
+      "query": "SELECT * FROM processes WHERE LOWER(name)='lsass.exe' AND LOWER(path)!='c:\\windows\\system32\\lsass.exe' AND path!='';",
+      "version": "2.2.1"
     },
     "services.exe_incorrect_parent_process": {
+      "description": "Detect processes masquerading as legitimate Windows processes",
+      "interval": 3600,
       "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE LOWER(name)='services.exe') AND LOWER(name)!='wininit.exe';",
-      "interval": 3600,
-      "version": "2.2.1",
-      "description": "Detect processes masquerading as legitimate Windows processes"
-    },
-    "svchost.exe_incorrect_path": {
-      "query": "SELECT * FROM processes WHERE LOWER(name)='svchost.exe' AND LOWER(path)!='c:\\windows\\system32\\svchost.exe' AND LOWER(path)!='c:\\windows\\syswow64\\svchost.exe' AND path!='';",
-      "interval": 3600,
-      "version": "2.2.1",
-      "description": "Detect processes masquerading as legitimate Windows processes"
+      "version": "2.2.1"
     },
     "svchost.exe_incorrect_parent_process": {
-      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE LOWER(name)='svchost.exe') AND LOWER(name)!='services.exe';",
+      "description": "Detect processes masquerading as legitimate Windows processes",
       "interval": 3600,
-      "version": "2.2.1",
-      "description": "Detect processes masquerading as legitimate Windows processes"
+      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE LOWER(name)='svchost.exe') AND LOWER(name)!='services.exe';",
+      "version": "2.2.1"
+    },
+    "svchost.exe_incorrect_path": {
+      "description": "Detect processes masquerading as legitimate Windows processes",
+      "interval": 3600,
+      "query": "SELECT * FROM processes WHERE LOWER(name)='svchost.exe' AND LOWER(path)!='c:\\windows\\system32\\svchost.exe' AND LOWER(path)!='c:\\windows\\syswow64\\svchost.exe' AND path!='';",
+      "version": "2.2.1"
+    },
+    "unTabs_1": {
+      "description": "(https://sensorstechforum.com/untabs-browser-extension-virus-remove-completely/)",
+      "interval": "3600",
+      "query": "select * from programs where name like 'unTabs%';",
+      "value": "Artifact used by this malware",
+      "version": "2.2.1"
+    },
+    "unTabs_2": {
+      "description": "(https://sensorstechforum.com/untabs-browser-extension-virus-remove-completely/)",
+      "interval": "3600",
+      "query": "select * from chrome_extensions join users using (uid) where name like 'unTabs%';",
+      "value": "Artifact used by this malware",
+      "version": "2.2.1"
     }
   }
 }

--- a/output/packs/windows-hardening.conf
+++ b/output/packs/windows-hardening.conf
@@ -1,0 +1,240 @@
+{
+  "platform": "windows",
+  "queries": {
+    "OpenType_Font_Driver_Vulnerability": {
+      "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\%' AND name = 'DisableATMFD' AND data != '1';",
+      "interval" : "3600",
+      "version": "2.2.1",
+      "description" : "Determine if Adobe Type Manager Font Driver is disabled (https://technet.microsoft.com/en-us/library/security/ms15-078)"
+    },
+    "Protecting_Against_Weak_Crypto_Algo": {
+      "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CertDllCreateCertificateChainEngine\\Config\\Default\\%' AND name IN ('WeakSha1ThirdPartyFlags','WeakMd5ThirdPartyFlags') AND type = 'REG_DWORD' AND data not like '-2%';",
+      "interval" : "3600",
+      "version": "2.2.1",
+      "description" : "Determine if Windows is configured to log certificates with weak crypto (https://technet.microsoft.com/library/dn375961(v=ws.11).aspx)",
+      "value" : "Artifact used by this malware"
+    },
+    "UAC_Disabled": {
+      "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\EnableLUA' AND data=0;",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Controls UAC. A setting of 0 indicates that UAC is disabled."
+    },
+    "SecureBoot": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecureBoot\\State\\UEFISecureBootEnabled'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Whether Secureboot is enabled"
+    },
+    "FontBlocking": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\MitigationOptions\\MitigationOptions_FontBlocking'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Whether FontBlocking is enabled"
+    },
+    "DepPolicy": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SystemStartOptions'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Whether DEP is enabled"
+    },
+    "MitigationOptions": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Kernel\\MitigationOptions'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Whether DEP is enabled with application mitigation options"
+    },
+    "MoveImages": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\\moveImages'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check ASLR configuration"
+    },
+    "KernelSehopEnabled": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Kernel\\KernelSEHOPEnabled'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Whether SEHOP is enabled"
+    },
+    "EnableCertPaddingCheck": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\WinTrust\\Config\\EnableCertPaddingCheck'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Determine state of Certificate Padding (https://docs.microsoft.com/en-us/security-updates/securityadvisories/2014/2915720)"
+    },
+    "EnableCertPaddingCheck_wow64": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Cryptography\\WinTrust\\Config\\EnableCertPaddingCheck'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Determine state of Certificate Padding (https://docs.microsoft.com/en-us/security-updates/securityadvisories/2014/2915720)"
+    },
+    "CwdIllegalInDllSearch": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\CWDIllegalInDllSearch'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Secure Search Path state (https://support.microsoft.com/en-us/help/2264107/a-new-cwdillegalindllsearch-registry-entry-is-available-to-control-the)"
+    },
+    "DisabledExceptionChainValidation": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\kernel\\DisableExceptionChainValidation'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check SEHOP state: DisabledExceptionChainValidation"
+    },
+    "EnableLowVaAccess": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\\EnableLowVaAccess'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Kernel Null page state"
+    },
+    "ControlFlowGuard": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\\EnableCfg'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Control Flow Guard state"
+    },
+    "App_ExecuteOptions": {
+      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\%Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%\\executeOptions'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Applications opted in for DEP"
+    },
+    "App_MitigationOptions": {
+      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\%Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%\\MitigationOptions'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Applications opted in for DEP"
+    },
+    "AppCompat": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\%Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Layers'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Applications opted in for DEP"
+    },
+    "App_disabledExceptionChainValidation": {
+      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\%Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%\\DisableExceptionChainValidation'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Applications not supporting SEHOP"
+    },
+    "DefaultLevelMachine": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\DefaultLevel'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state"
+    },
+    "DefaultLevelUser": {
+      "query" : "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\DefaultLevel'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state"
+    },
+    "PolicyScopeMachine": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\PolicyScope'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state"
+    },
+    "PolicyScopeUser": {
+      "query" : "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\PolicyScope'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state"
+    },
+    "ExecutableTryMachine": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\ExecutableTry'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state"
+    },
+    "ExecutableTryUser": {
+      "query" : "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\ExecutableTry'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state"
+    },
+    "TransparentEnabledMachine": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\TransparentEnabled'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state"
+    },
+    "TransparentEnabledUser": {
+      "query" : "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\TransparentEnabled'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state"
+    },
+    "Unrestricted": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\262144'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state: No SRP whitelist rules"
+    },
+    "Unrestricted_Paths": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\262144\\Paths'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state: No SRP path rules"
+    },
+    "Unrestricted_Paths_ItemData": {
+      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\262144\\Paths\\%\\ItemData'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state: SRP whitelist rules is missing"
+    },
+    "Disallowed": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\0'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state: No SRP blacklist rules"
+    },
+    "Disallowed_Paths": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\0\\Paths'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state: No SRP path rules"
+    },
+    "Disallowed_Paths_ItemData": {
+      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\0\\Paths\\%\\ItemData'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state: SRP blacklist rule is missing"
+    },
+    "SaferFlags": {
+      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\%\\%\\%\\SaferFlags'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Software Restriction Policies state: SRP rule is not enforcing"
+    },
+    "RuleSetEnforcementMode": {
+      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\SrpV2\\%\\EnforcementMode'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Applocker rule set configuration"
+    },
+    "Rule": {
+      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\SrpV2\\%\\%\\Value'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Applocker rule set"
+    },
+    "AuditSpecialGroups": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\Audit'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Special Logon Audit configuration - https://blogs.technet.microsoft.com/jepayne/2015/11/26/tracking-lateral-movement-part-one-special-groups-and-specific-service-accounts/"
+    },
+    "SysmonConfig": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CCS\\Services\\SysmonDrv\\Parameters'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Microsoft Sysinternals Sysmon config"
+    },
+    "DeveloperMode": {
+      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock'",
+      "interval": "86400",
+      "snapshot": true,
+      "description" : "Check Developer Mode state"
+    }
+  }
+}

--- a/output/packs/windows-hardening.conf
+++ b/output/packs/windows-hardening.conf
@@ -1,240 +1,240 @@
 {
   "platform": "windows",
   "queries": {
-    "OpenType_Font_Driver_Vulnerability": {
-      "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\%' AND name = 'DisableATMFD' AND data != '1';",
-      "interval" : "3600",
-      "version": "2.2.1",
-      "description" : "Determine if Adobe Type Manager Font Driver is disabled (https://technet.microsoft.com/en-us/library/security/ms15-078)"
-    },
-    "Protecting_Against_Weak_Crypto_Algo": {
-      "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CertDllCreateCertificateChainEngine\\Config\\Default\\%' AND name IN ('WeakSha1ThirdPartyFlags','WeakMd5ThirdPartyFlags') AND type = 'REG_DWORD' AND data not like '-2%';",
-      "interval" : "3600",
-      "version": "2.2.1",
-      "description" : "Determine if Windows is configured to log certificates with weak crypto (https://technet.microsoft.com/library/dn375961(v=ws.11).aspx)",
-      "value" : "Artifact used by this malware"
-    },
-    "UAC_Disabled": {
-      "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\EnableLUA' AND data=0;",
-      "interval": 3600,
-      "version": "2.2.1",
-      "description": "Controls UAC. A setting of 0 indicates that UAC is disabled."
-    },
-    "SecureBoot": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecureBoot\\State\\UEFISecureBootEnabled'",
+    "AppCompat": {
+      "description": "Check Applications opted in for DEP",
       "interval": "86400",
-      "snapshot": true,
-      "description" : "Whether Secureboot is enabled"
-    },
-    "FontBlocking": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\MitigationOptions\\MitigationOptions_FontBlocking'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Whether FontBlocking is enabled"
-    },
-    "DepPolicy": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SystemStartOptions'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Whether DEP is enabled"
-    },
-    "MitigationOptions": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Kernel\\MitigationOptions'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Whether DEP is enabled with application mitigation options"
-    },
-    "MoveImages": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\\moveImages'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check ASLR configuration"
-    },
-    "KernelSehopEnabled": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Kernel\\KernelSEHOPEnabled'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Whether SEHOP is enabled"
-    },
-    "EnableCertPaddingCheck": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\WinTrust\\Config\\EnableCertPaddingCheck'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Determine state of Certificate Padding (https://docs.microsoft.com/en-us/security-updates/securityadvisories/2014/2915720)"
-    },
-    "EnableCertPaddingCheck_wow64": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Cryptography\\WinTrust\\Config\\EnableCertPaddingCheck'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Determine state of Certificate Padding (https://docs.microsoft.com/en-us/security-updates/securityadvisories/2014/2915720)"
-    },
-    "CwdIllegalInDllSearch": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\CWDIllegalInDllSearch'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Secure Search Path state (https://support.microsoft.com/en-us/help/2264107/a-new-cwdillegalindllsearch-registry-entry-is-available-to-control-the)"
-    },
-    "DisabledExceptionChainValidation": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\kernel\\DisableExceptionChainValidation'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check SEHOP state: DisabledExceptionChainValidation"
-    },
-    "EnableLowVaAccess": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\\EnableLowVaAccess'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Kernel Null page state"
-    },
-    "ControlFlowGuard": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\\EnableCfg'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Control Flow Guard state"
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\%Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Layers'",
+      "snapshot": true
     },
     "App_ExecuteOptions": {
-      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\%Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%\\executeOptions'",
+      "description": "Check Applications opted in for DEP",
       "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Applications opted in for DEP"
+      "query": "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\%Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%\\executeOptions'",
+      "snapshot": true
     },
     "App_MitigationOptions": {
-      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\%Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%\\MitigationOptions'",
+      "description": "Check Applications opted in for DEP",
       "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Applications opted in for DEP"
-    },
-    "AppCompat": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\%Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Layers'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Applications opted in for DEP"
+      "query": "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\%Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%\\MitigationOptions'",
+      "snapshot": true
     },
     "App_disabledExceptionChainValidation": {
-      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\%Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%\\DisableExceptionChainValidation'",
+      "description": "Check Applications not supporting SEHOP",
       "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Applications not supporting SEHOP"
-    },
-    "DefaultLevelMachine": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\DefaultLevel'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state"
-    },
-    "DefaultLevelUser": {
-      "query" : "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\DefaultLevel'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state"
-    },
-    "PolicyScopeMachine": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\PolicyScope'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state"
-    },
-    "PolicyScopeUser": {
-      "query" : "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\PolicyScope'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state"
-    },
-    "ExecutableTryMachine": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\ExecutableTry'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state"
-    },
-    "ExecutableTryUser": {
-      "query" : "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\ExecutableTry'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state"
-    },
-    "TransparentEnabledMachine": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\TransparentEnabled'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state"
-    },
-    "TransparentEnabledUser": {
-      "query" : "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\TransparentEnabled'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state"
-    },
-    "Unrestricted": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\262144'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state: No SRP whitelist rules"
-    },
-    "Unrestricted_Paths": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\262144\\Paths'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state: No SRP path rules"
-    },
-    "Unrestricted_Paths_ItemData": {
-      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\262144\\Paths\\%\\ItemData'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state: SRP whitelist rules is missing"
-    },
-    "Disallowed": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\0'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state: No SRP blacklist rules"
-    },
-    "Disallowed_Paths": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\0\\Paths'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state: No SRP path rules"
-    },
-    "Disallowed_Paths_ItemData": {
-      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\0\\Paths\\%\\ItemData'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state: SRP blacklist rule is missing"
-    },
-    "SaferFlags": {
-      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\%\\%\\%\\SaferFlags'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Software Restriction Policies state: SRP rule is not enforcing"
-    },
-    "RuleSetEnforcementMode": {
-      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\SrpV2\\%\\EnforcementMode'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Applocker rule set configuration"
-    },
-    "Rule": {
-      "query" : "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\SrpV2\\%\\%\\Value'",
-      "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Applocker rule set"
+      "query": "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\%Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%\\DisableExceptionChainValidation'",
+      "snapshot": true
     },
     "AuditSpecialGroups": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\Audit'",
+      "description": "Check Special Logon Audit configuration - https://blogs.technet.microsoft.com/jepayne/2015/11/26/tracking-lateral-movement-part-one-special-groups-and-specific-service-accounts/",
       "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Special Logon Audit configuration - https://blogs.technet.microsoft.com/jepayne/2015/11/26/tracking-lateral-movement-part-one-special-groups-and-specific-service-accounts/"
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\Audit'",
+      "snapshot": true
     },
-    "SysmonConfig": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CCS\\Services\\SysmonDrv\\Parameters'",
+    "ControlFlowGuard": {
+      "description": "Check Control Flow Guard state",
       "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Microsoft Sysinternals Sysmon config"
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\\EnableCfg'",
+      "snapshot": true
+    },
+    "CwdIllegalInDllSearch": {
+      "description": "Check Secure Search Path state (https://support.microsoft.com/en-us/help/2264107/a-new-cwdillegalindllsearch-registry-entry-is-available-to-control-the)",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\CWDIllegalInDllSearch'",
+      "snapshot": true
+    },
+    "DefaultLevelMachine": {
+      "description": "Check Software Restriction Policies state",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\DefaultLevel'",
+      "snapshot": true
+    },
+    "DefaultLevelUser": {
+      "description": "Check Software Restriction Policies state",
+      "interval": "86400",
+      "query": "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\DefaultLevel'",
+      "snapshot": true
+    },
+    "DepPolicy": {
+      "description": "Whether DEP is enabled",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SystemStartOptions'",
+      "snapshot": true
     },
     "DeveloperMode": {
-      "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock'",
+      "description": "Check Developer Mode state",
       "interval": "86400",
-      "snapshot": true,
-      "description" : "Check Developer Mode state"
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock'",
+      "snapshot": true
+    },
+    "DisabledExceptionChainValidation": {
+      "description": "Check SEHOP state: DisabledExceptionChainValidation",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\kernel\\DisableExceptionChainValidation'",
+      "snapshot": true
+    },
+    "Disallowed": {
+      "description": "Check Software Restriction Policies state: No SRP blacklist rules",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\0'",
+      "snapshot": true
+    },
+    "Disallowed_Paths": {
+      "description": "Check Software Restriction Policies state: No SRP path rules",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\0\\Paths'",
+      "snapshot": true
+    },
+    "Disallowed_Paths_ItemData": {
+      "description": "Check Software Restriction Policies state: SRP blacklist rule is missing",
+      "interval": "86400",
+      "query": "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\0\\Paths\\%\\ItemData'",
+      "snapshot": true
+    },
+    "EnableCertPaddingCheck": {
+      "description": "Determine state of Certificate Padding (https://docs.microsoft.com/en-us/security-updates/securityadvisories/2014/2915720)",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\WinTrust\\Config\\EnableCertPaddingCheck'",
+      "snapshot": true
+    },
+    "EnableCertPaddingCheck_wow64": {
+      "description": "Determine state of Certificate Padding (https://docs.microsoft.com/en-us/security-updates/securityadvisories/2014/2915720)",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Cryptography\\WinTrust\\Config\\EnableCertPaddingCheck'",
+      "snapshot": true
+    },
+    "EnableLowVaAccess": {
+      "description": "Check Kernel Null page state",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\\EnableLowVaAccess'",
+      "snapshot": true
+    },
+    "ExecutableTryMachine": {
+      "description": "Check Software Restriction Policies state",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\ExecutableTry'",
+      "snapshot": true
+    },
+    "ExecutableTryUser": {
+      "description": "Check Software Restriction Policies state",
+      "interval": "86400",
+      "query": "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\ExecutableTry'",
+      "snapshot": true
+    },
+    "FontBlocking": {
+      "description": "Whether FontBlocking is enabled",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\MitigationOptions\\MitigationOptions_FontBlocking'",
+      "snapshot": true
+    },
+    "KernelSehopEnabled": {
+      "description": "Whether SEHOP is enabled",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Kernel\\KernelSEHOPEnabled'",
+      "snapshot": true
+    },
+    "MitigationOptions": {
+      "description": "Whether DEP is enabled with application mitigation options",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Kernel\\MitigationOptions'",
+      "snapshot": true
+    },
+    "MoveImages": {
+      "description": "Check ASLR configuration",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\\moveImages'",
+      "snapshot": true
+    },
+    "OpenType_Font_Driver_Vulnerability": {
+      "description": "Determine if Adobe Type Manager Font Driver is disabled (https://technet.microsoft.com/en-us/library/security/ms15-078)",
+      "interval": "3600",
+      "query": "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\%' AND name = 'DisableATMFD' AND data != '1';",
+      "version": "2.2.1"
+    },
+    "PolicyScopeMachine": {
+      "description": "Check Software Restriction Policies state",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\PolicyScope'",
+      "snapshot": true
+    },
+    "PolicyScopeUser": {
+      "description": "Check Software Restriction Policies state",
+      "interval": "86400",
+      "query": "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\PolicyScope'",
+      "snapshot": true
+    },
+    "Protecting_Against_Weak_Crypto_Algo": {
+      "description": "Determine if Windows is configured to log certificates with weak crypto (https://technet.microsoft.com/library/dn375961(v=ws.11).aspx)",
+      "interval": "3600",
+      "query": "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CertDllCreateCertificateChainEngine\\Config\\Default\\%' AND name IN ('WeakSha1ThirdPartyFlags','WeakMd5ThirdPartyFlags') AND type = 'REG_DWORD' AND data not like '-2%';",
+      "value": "Artifact used by this malware",
+      "version": "2.2.1"
+    },
+    "Rule": {
+      "description": "Check Applocker rule set",
+      "interval": "86400",
+      "query": "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\SrpV2\\%\\%\\Value'",
+      "snapshot": true
+    },
+    "RuleSetEnforcementMode": {
+      "description": "Check Applocker rule set configuration",
+      "interval": "86400",
+      "query": "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\SrpV2\\%\\EnforcementMode'",
+      "snapshot": true
+    },
+    "SaferFlags": {
+      "description": "Check Software Restriction Policies state: SRP rule is not enforcing",
+      "interval": "86400",
+      "query": "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\%\\%\\%\\SaferFlags'",
+      "snapshot": true
+    },
+    "SecureBoot": {
+      "description": "Whether Secureboot is enabled",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecureBoot\\State\\UEFISecureBootEnabled'",
+      "snapshot": true
+    },
+    "SysmonConfig": {
+      "description": "Check Microsoft Sysinternals Sysmon config",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CCS\\Services\\SysmonDrv\\Parameters'",
+      "snapshot": true
+    },
+    "TransparentEnabledMachine": {
+      "description": "Check Software Restriction Policies state",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\TransparentEnabled'",
+      "snapshot": true
+    },
+    "TransparentEnabledUser": {
+      "description": "Check Software Restriction Policies state",
+      "interval": "86400",
+      "query": "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\TransparentEnabled'",
+      "snapshot": true
+    },
+    "UAC_Disabled": {
+      "description": "Controls UAC. A setting of 0 indicates that UAC is disabled.",
+      "interval": 3600,
+      "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\EnableLUA' AND data=0;",
+      "version": "2.2.1"
+    },
+    "Unrestricted": {
+      "description": "Check Software Restriction Policies state: No SRP whitelist rules",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\262144'",
+      "snapshot": true
+    },
+    "Unrestricted_Paths": {
+      "description": "Check Software Restriction Policies state: No SRP path rules",
+      "interval": "86400",
+      "query": "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\262144\\Paths'",
+      "snapshot": true
+    },
+    "Unrestricted_Paths_ItemData": {
+      "description": "Check Software Restriction Policies state: SRP whitelist rules is missing",
+      "interval": "86400",
+      "query": "select * from registry where key like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Safer\\CodeIdentifiers\\262144\\Paths\\%\\ItemData'",
+      "snapshot": true
     }
   }
 }


### PR DESCRIPTION
Initial import of the osquery packs. This is meant as a base to start iterating on.

These were cleaned up by removing the bad-json newlines, and sorting with jq.

```
cat osx-attacks.conf-orig | ruby -e 'puts STDIN.read.gsub("\\\n", " ")' > osx-attacks.conf
for f in *conf; do mv $f $f.orig; jq -S . $f.orig > $f; done
```